### PR TITLE
Setter allowAllUsers: false

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -60,8 +60,8 @@ spec:
     enabled: true
   azure:
     application:
-      allowAllUsers: true
       enabled: true
+      allowAllUsers: false
       claims:
         extra:
           - "NAVident"


### PR DESCRIPTION
Siden vi har tatt inn k9 sin driftsrolle trenger vi ikke lenger å ha allowAllUsers. Når vi setter den til false vil kun de med denne rollen få tilgang.
Se https://doc.nais.io/auth/entra-id/how-to/secure/