### PR TITLE
Rename felter i omsorgspenger request så det matcher frontend

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/SendInntektsmeldingRequestDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/SendInntektsmeldingRequestDto.java
@@ -53,22 +53,22 @@ public record SendInntektsmeldingRequestDto(@Valid UUID foresporselUuid,
     }
 
     public record OmsorgspengerRequestDto(@NotNull Boolean harUtbetaltPliktigeDager,
-                                          List<@Valid FraværsPeriodeRequestDto> fraværsPerioder,
-                                          List<@Valid DelvisFraværsPeriodeRequestDto> delvisFraværsPerioder) {
+                                          List<@Valid FraværHeleDagerRequestDto> fraværHeleDager,
+                                          List<@Valid FraværDelerAvDagenRequestDto> fraværDelerAvDagen) {
 
-        public record FraværsPeriodeRequestDto(@NotNull LocalDate fom,
-                                               @NotNull LocalDate tom) {
+        public record FraværHeleDagerRequestDto(@NotNull LocalDate fom,
+                                                @NotNull LocalDate tom) {
 
         }
 
-        public record DelvisFraværsPeriodeRequestDto(@NotNull LocalDate dato,
-                                                     @NotNull @Min(0) @Max(Integer.MAX_VALUE) @Digits(integer = 2, fraction = 2) BigDecimal timer) {
+        public record FraværDelerAvDagenRequestDto(@NotNull LocalDate dato,
+                                                   @NotNull @Min(0) @Max(Integer.MAX_VALUE) @Digits(integer = 2, fraction = 2) BigDecimal timer) {
         }
 
-        @AssertTrue(message = "Må ha enten fraværsPerioder eller delvisFraværsPerioder")
+        @AssertTrue(message = "Må ha enten fraværHeleDager eller fraværDelerAvDagen")
         private boolean isValidFraværsPerioderOrDelvisFraværsPerioder() {
-            if (fraværsPerioder == null || fraværsPerioder.isEmpty()) {
-                return !(delvisFraværsPerioder == null || delvisFraværsPerioder.isEmpty());
+            if (fraværHeleDager == null || fraværHeleDager.isEmpty()) {
+                return !(fraværDelerAvDagen == null || fraværDelerAvDagen.isEmpty());
             }
             return true;
         }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapper.java
@@ -163,11 +163,11 @@ public class InntektsmeldingMapper {
             omsorgspengerEntitet.isHarUtbetaltPliktigeDager(),
             omsorgspengerEntitet.getFraværsPerioder()
                 .stream()
-                .map(fravær -> new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværsPeriodeRequestDto(fravær.getPeriode().getFom(), fravær.getPeriode().getTom()))
+                .map(fravær -> new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværHeleDagerRequestDto(fravær.getPeriode().getFom(), fravær.getPeriode().getTom()))
                 .toList(),
             omsorgspengerEntitet.getDelvisFraværsPerioder()
                 .stream()
-                .map(delvisFravær -> new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.DelvisFraværsPeriodeRequestDto(delvisFravær.getDato(), delvisFravær.getTimer()))
+                .map(delvisFravær -> new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværDelerAvDagenRequestDto(delvisFravær.getDato(), delvisFravær.getTimer()))
                 .toList()
         );
 
@@ -233,12 +233,12 @@ public class InntektsmeldingMapper {
     private static OmsorgspengerEntitet mapOmsorgspenger(SendInntektsmeldingRequestDto.OmsorgspengerRequestDto dto) {
         return OmsorgspengerEntitet.builder()
             .medHarUtbetaltPliktigeDager(dto.harUtbetaltPliktigeDager())
-            .medFraværsPerioder(mapFraværsPerioder(dto.fraværsPerioder()))
-            .medDelvisFraværsPerioder(mapDelvisFraværsPerioder(dto.delvisFraværsPerioder()))
+            .medFraværsPerioder(mapFraværsPerioder(dto.fraværHeleDager()))
+            .medDelvisFraværsPerioder(mapDelvisFraværsPerioder(dto.fraværDelerAvDagen()))
             .build();
     }
 
-    private static List<FraværsPeriodeEntitet> mapFraværsPerioder(List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværsPeriodeRequestDto> dto) {
+    private static List<FraværsPeriodeEntitet> mapFraværsPerioder(List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværHeleDagerRequestDto> dto) {
         if (dto == null) {
             return null;
         }
@@ -247,7 +247,7 @@ public class InntektsmeldingMapper {
             .toList();
     }
 
-    private static List<DelvisFraværsPeriodeEntitet> mapDelvisFraværsPerioder(List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.DelvisFraværsPeriodeRequestDto> dto) {
+    private static List<DelvisFraværsPeriodeEntitet> mapDelvisFraværsPerioder(List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværDelerAvDagenRequestDto> dto) {
         if (dto == null) {
             return null;
         }

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapperTest.java
@@ -190,7 +190,7 @@ class InntektsmeldingMapperTest {
         var forventetFraværsFom = LocalDate.now();
         var forventetFraværsTom = LocalDate.now().plusDays(5);
         var omsorgspenger = new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto(true,
-            List.of(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværsPeriodeRequestDto(forventetFraværsFom, forventetFraværsTom)),
+            List.of(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværHeleDagerRequestDto(forventetFraværsFom, forventetFraværsTom)),
             null);
 
         var request = new SendInntektsmeldingRequestDto(UUID.randomUUID(),
@@ -233,7 +233,7 @@ class InntektsmeldingMapperTest {
         var forventetAntallFraværsTimer = BigDecimal.valueOf(3);
         var omsorgspenger = new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto(true,
             null,
-            List.of(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.DelvisFraværsPeriodeRequestDto(forventetDelvisFraværsDato, forventetAntallFraværsTimer)));
+            List.of(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværDelerAvDagenRequestDto(forventetDelvisFraværsDato, forventetAntallFraværsTimer)));
 
         var request = new SendInntektsmeldingRequestDto(UUID.randomUUID(),
             new AktørIdDto("9999999999999"),
@@ -544,9 +544,9 @@ class InntektsmeldingMapperTest {
         assertThat(imDto.endringAvInntektÅrsaker().get(1).årsak()).isEqualTo(EndringsårsakDto.TARIFFENDRING);
         assertThat(imDto.omsorgspenger()).isNotNull();
         assertThat(imDto.omsorgspenger().harUtbetaltPliktigeDager()).isTrue();
-        assertThat(imDto.omsorgspenger().fraværsPerioder()).hasSize(1);
-        assertThat(imDto.omsorgspenger().fraværsPerioder().getFirst().fom()).isEqualTo(imEntitet.getOmsorgspenger().getFraværsPerioder().getFirst().getPeriode().getFom());
-        assertThat(imDto.omsorgspenger().fraværsPerioder().getFirst().tom()).isEqualTo(imEntitet.getOmsorgspenger().getFraværsPerioder().getFirst().getPeriode().getTom());
-        assertThat(imDto.omsorgspenger().delvisFraværsPerioder()).isEmpty();
+        assertThat(imDto.omsorgspenger().fraværHeleDager()).hasSize(1);
+        assertThat(imDto.omsorgspenger().fraværHeleDager().getFirst().fom()).isEqualTo(imEntitet.getOmsorgspenger().getFraværsPerioder().getFirst().getPeriode().getFom());
+        assertThat(imDto.omsorgspenger().fraværHeleDager().getFirst().tom()).isEqualTo(imEntitet.getOmsorgspenger().getFraværsPerioder().getFirst().getPeriode().getTom());
+        assertThat(imDto.omsorgspenger().fraværDelerAvDagen()).isEmpty();
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/typer/OmsorgspengerRequestDtoTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/typer/OmsorgspengerRequestDtoTest.java
@@ -32,8 +32,8 @@ public class OmsorgspengerRequestDtoTest {
 
     @Test
     public void testValidFraværsPerioder() {
-        List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværsPeriodeRequestDto> fraværsPerioder = new ArrayList<>();
-        fraværsPerioder.add(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværsPeriodeRequestDto(LocalDate.now(), LocalDate.now().plusDays(1)));
+        List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværHeleDagerRequestDto> fraværsPerioder = new ArrayList<>();
+        fraværsPerioder.add(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværHeleDagerRequestDto(LocalDate.now(), LocalDate.now().plusDays(1)));
 
         SendInntektsmeldingRequestDto.OmsorgspengerRequestDto dto = new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto(true, fraværsPerioder, new ArrayList<>());
 
@@ -43,8 +43,8 @@ public class OmsorgspengerRequestDtoTest {
 
     @Test
     public void testValidDelvisFraværsPerioder() {
-        List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.DelvisFraværsPeriodeRequestDto> delvisFraværsPerioder = new ArrayList<>();
-        delvisFraværsPerioder.add(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.DelvisFraværsPeriodeRequestDto(LocalDate.now(), new BigDecimal("2.5")));
+        List<SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværDelerAvDagenRequestDto> delvisFraværsPerioder = new ArrayList<>();
+        delvisFraværsPerioder.add(new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto.FraværDelerAvDagenRequestDto(LocalDate.now(), new BigDecimal("2.5")));
 
         SendInntektsmeldingRequestDto.OmsorgspengerRequestDto dto = new SendInntektsmeldingRequestDto.OmsorgspengerRequestDto(true, new ArrayList<>(), delvisFraværsPerioder);
 


### PR DESCRIPTION
### Bakgrunn
Frontende har en litt annen ordlyd på feltene som sendes for omsorgspenger. Backend har brukt samme navn som vi mapper til i xml-en, men de som frontend bruker er mer beskrivende, så vi ønsker å heller bruke de. 

### Løsning
Rename:
-  FraværsPeriodeRequestDto -> FraværHeleDagerRequestDto 
- DelvisFraværsPeriodeRequestDto -> FraværDelerAvDagenRequestDto