### PR TITLE
Hent organisasjonsnavn for arbeidsforholdene ved henting av arbeidstaker

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -53,7 +53,7 @@ public class ArbeidsgiverinitiertDialogRest {
         if (erProd) {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
-        LOG.info("Henter arbeidsforhold for søker {}", request.fødselsnummer());
+        LOG.info("Henter arbeidsforhold for søker");
         var dto = inntektsmeldingTjeneste.finnArbeidsforholdForFnr(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag());
         return dto.map(d ->Response.ok(d).build()).orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
@@ -66,7 +66,7 @@ public class ArbeidsgiverinitiertDialogRest {
         if (erProd) {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
-        LOG.info("Henter opplysninger for søker {}", request.fødselsnummer());
+        LOG.info("Henter opplysninger for søker");
         var dto = inntektsmeldingTjeneste.lagArbeidsgiverinitiertDialogDto(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag(), request.organisasjonsnummer());
         return Response.ok(dto).build();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponseDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponseDto.java
@@ -10,4 +10,6 @@ public record SlåOppArbeidstakerResponseDto(Personinformasjon personinformasjon
         String fødselsnummer,
         String aktørId) {
     }
+    public record ArbeidsforholdDto(String organisasjonsnummer, String arbeidsforholdId, String organisasjonsnavn) {
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -5,18 +5,14 @@ import java.time.LocalDate;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingDialogDto;
-
-import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsopplysningerResponseDto;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
-import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsopplysningerResponseDto;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.InnloggetBrukerDto;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.SlåOppArbeidstakerResponseDto;
 
@@ -41,7 +37,7 @@ public class RefusjonOmsorgsdagerService {
     }
 
     public SlåOppArbeidstakerResponseDto hentArbeidstaker(PersonIdent fødselsnummer) {
-        LOG.info("Slår opp arbeidstaker med fødselsnummer {}", fødselsnummer);
+        LOG.info("Slår opp arbeidstaker");
 
         var arbeidsforhold = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer,
             LocalDate.now());

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 
 import jakarta.ws.rs.core.Response;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.RefusjonOmsorgsdagerService;
@@ -41,7 +39,7 @@ class RefusjonOmsorgsdagerRestTest {
     void slå_opp_arbeidstaker_skal_returnere_ok_response_når_arbeidstaker_finnes() {
         var fnr = PersonIdent.fra("12345678910");
         var dto = new SlåOppArbeidstakerRequestDto(fnr, Ytelsetype.OMSORGSPENGER);
-        var arbeidsforhold = List.of(new ArbeidsforholdDto("999999999", "ARB-1"));
+        var arbeidsforhold = List.of(new SlåOppArbeidstakerResponseDto.ArbeidsforholdDto("999999999", "ARB-1", "Arbeidsgiver AS"));
         var arbeidstakerInfo = new SlåOppArbeidstakerResponseDto(new SlåOppArbeidstakerResponseDto.Personinformasjon("fornavn", "mellomnavn", "etternavn", "10107400090", "12345"), arbeidsforhold);
 
         when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr)).thenReturn(arbeidstakerInfo);


### PR DESCRIPTION
### Bakgrunn
Vi ønsker å vise organisasjonsnavnet for arbeidsgiveren for en enklere visuell bekreftelse i skjemaet for omsorgspenger refusjon.

### Løsning
Henter organisasjonsnavnet tilsvarende som vi gjør i `InntektsmeldingTjeneste`.