### PR TITLE
Justerer CPU request i prod

### DIFF
--- a/.deploy/prod-gcp.json
+++ b/.deploy/prod-gcp.json
@@ -7,7 +7,7 @@
     "mem": "2048Mi"
   },
   "requests": {
-    "cpu": "500m",
+    "cpu": "200m",
     "mem": "1024Mi"
   },
   "ingresses": [


### PR DESCRIPTION
Vi bruker mye mindre enn vi spør om, se https://console.nav.cloud.nais.io/team/k9saksbehandling/prod-gcp/app/k9-inntektsmelding/utilization?interval=30d
200m er det samme som k9-sak spør om. k9-inntektsmelding bør hvertfall ikke trenge mer enn k9-sak.