### PR TITLE
POFIM-204: Generer pdf for omsorgspenger refusjon med nytt endepunkt

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfData.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfData.java
@@ -33,7 +33,6 @@ public class InntektsmeldingPdfData {
     private boolean ingenGjenopptattNaturalytelse;
     private List<Endringsarsak> endringsarsaker = new ArrayList<>();
     private int antallRefusjonsperioder;
-    private Omsorgspenger omsorgspenger;
 
     public String getAvsenderSystem() {
         return avsenderSystem;
@@ -99,10 +98,6 @@ public class InntektsmeldingPdfData {
         return antallRefusjonsperioder;
     }
 
-    public Omsorgspenger getOmsorgspenger() {
-        return omsorgspenger;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -127,15 +122,14 @@ public class InntektsmeldingPdfData {
             && Objects.equals(refusjonsendringer, that.refusjonsendringer)
             && Objects.equals(naturalytelser, that.naturalytelser)
             && Objects.equals(endringsarsaker, that.endringsarsaker)
-            && Objects.equals(antallRefusjonsperioder, that.antallRefusjonsperioder)
-            && Objects.equals(omsorgspenger, that.omsorgspenger);
+            && Objects.equals(antallRefusjonsperioder, that.antallRefusjonsperioder);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(avsenderSystem, navnSøker, personnummer, ytelsetype, arbeidsgiverIdent, arbeidsgiverNavn, kontaktperson,
             startDato, månedInntekt, opprettetTidspunkt, refusjonsendringer, naturalytelser,
-            ingenBortfaltNaturalytelse, ingenGjenopptattNaturalytelse, endringsarsaker, antallRefusjonsperioder, omsorgspenger);
+            ingenBortfaltNaturalytelse, ingenGjenopptattNaturalytelse, endringsarsaker, antallRefusjonsperioder);
     }
 
     public static String formaterPersonnummer(String personnummer) {
@@ -259,11 +253,6 @@ public class InntektsmeldingPdfData {
 
         public Builder medAntallRefusjonsperioder(int antallRefusjonsperioder) {
             this.kladd.antallRefusjonsperioder = antallRefusjonsperioder;
-            return this;
-        }
-
-        public Builder medOmsorgspenger(Omsorgspenger omsorgspenger) {
-            this.kladd.omsorgspenger = omsorgspenger;
             return this;
         }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfDataMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfDataMapper.java
@@ -55,10 +55,6 @@ public class InntektsmeldingPdfDataMapper {
             imDokumentdataBuilder.medAntallRefusjonsperioder(0);
         }
 
-        if (inntektsmelding.getOmsorgspenger() != null) {
-            imDokumentdataBuilder.medOmsorgspenger(mapOmsorgspenger(inntektsmelding.getOmsorgspenger()));
-        }
-
         return imDokumentdataBuilder.build();
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenKlient.java
@@ -6,7 +6,6 @@ import java.net.URISyntaxException;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.integrasjon.rest.FpApplication;
 import no.nav.vedtak.felles.integrasjon.rest.RestClient;
@@ -23,28 +22,23 @@ import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 public class K9DokgenKlient {
     private final RestClient restClient;
     private final RestConfig restConfig;
-    private final String templatePath;
-    private final String templateType;
+
+    private final String OMSORGSPENGER_REFUSJON_PATH = "/template/omsorgspenger_refusjon/PDFOMSORGSPENGERREFUSJON/create-pdf-format-variation";
+    private final String INNTEKTSMELDING_PATH = "/template/inntektsmelding/PDFINNTEKTSMELDING/create-pdf-format-variation";
 
     @Inject
     public K9DokgenKlient(
-        @KonfigVerdi(value = "pdf.template.path", defaultVerdi = "/template/inntektsmelding/PDFINNTEKTSMELDING") String tempatePath,
-        @KonfigVerdi(value = "pdf.template.type", defaultVerdi = "/create-pdf-format-variation") String templateType
     ) {
-        this(RestClient.client(), tempatePath, templateType);
+        this(RestClient.client());
     }
 
-    public K9DokgenKlient(RestClient restClient,
-                          String templatePath,
-                          String templateType) {
+    public K9DokgenKlient(RestClient restClient) {
         this.restClient = restClient;
         this.restConfig = RestConfig.forClient(K9DokgenKlient.class);
-        this.templatePath = templatePath;
-        this.templateType = templateType;
     }
 
     public byte[] genererPdf(InntektsmeldingPdfData dokumentdata) throws URISyntaxException {
-        var endpoint = new URI(restConfig.endpoint() + templatePath + templateType);
+        var endpoint = new URI(restConfig.endpoint() + INNTEKTSMELDING_PATH);
         var request = RestRequest.newPOSTJson(dokumentdata, endpoint, restConfig);
         var pdf = restClient.sendReturnByteArray(request);
 
@@ -55,8 +49,7 @@ public class K9DokgenKlient {
     }
 
     public byte[] genererPdfOmsorgspengerRefusjon(OmsorgspengerRefusjonPdfData dokumentdata) throws URISyntaxException {
-        var path = "/template/omsorgspenger_refusjon/PDFOMSORGSPENGERREFUSJON/create-pdf-format-variation";
-        var endpoint = new URI(restConfig.endpoint() + path);
+        var endpoint = new URI(restConfig.endpoint() + OMSORGSPENGER_REFUSJON_PATH);
         var request = RestRequest.newPOSTJson(dokumentdata, endpoint, restConfig);
         var pdf = restClient.sendReturnByteArray(request);
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenKlient.java
@@ -53,4 +53,16 @@ public class K9DokgenKlient {
         }
         return pdf;
     }
+
+    public byte[] genererPdfOmsorgspengerRefusjon(OmsorgspengerRefusjonPdfData dokumentdata) throws URISyntaxException {
+        var path = "/template/omsorgspenger_refusjon/PDFOMSORGSPENGERREFUSJON/create-pdf-format-variation";
+        var endpoint = new URI(restConfig.endpoint() + path);
+        var request = RestRequest.newPOSTJson(dokumentdata, endpoint, restConfig);
+        var pdf = restClient.sendReturnByteArray(request);
+
+        if (pdf == null || pdf.length == 0) {
+            throw new TekniskException("K9IM", "Fikk tomt svar ved kall til dokgen for generering av pdf for refusjonskrav omsorgspenger");
+        }
+        return pdf;
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfData.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfData.java
@@ -1,0 +1,205 @@
+package no.nav.familie.inntektsmelding.integrasjoner.dokgen;
+
+import static java.time.format.DateTimeFormatter.ofPattern;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class OmsorgspengerRefusjonPdfData {
+    private String avsenderSystem;
+    private String navnSøker;
+    private String personnummer;
+    private String arbeidsgiverIdent;
+    private String arbeidsgiverNavn;
+    private Kontaktperson kontaktperson;
+    private BigDecimal månedInntekt;
+    private String opprettetTidspunkt;
+    private List<Endringsarsak> endringsarsaker = new ArrayList<>();
+    private Omsorgspenger omsorgspenger;
+    private BigDecimal årForRefusjon;
+
+    public String getAvsenderSystem() {
+        return avsenderSystem;
+    }
+
+    public String getNavnSøker() {
+        return navnSøker;
+    }
+
+    public String getPersonnummer() {
+        return personnummer;
+    }
+
+    public String getArbeidsgiverIdent() {
+        return arbeidsgiverIdent;
+    }
+
+    public String getArbeidsgiverNavn() {
+        return arbeidsgiverNavn;
+    }
+
+    public Kontaktperson getKontaktperson() {
+        return kontaktperson;
+    }
+
+    public BigDecimal getMånedInntekt() {
+        return månedInntekt;
+    }
+
+    public String getOpprettetTidspunkt() {
+        return opprettetTidspunkt;
+    }
+
+    public List<Endringsarsak> getEndringsarsaker() {
+        return endringsarsaker;
+    }
+
+    public Omsorgspenger getOmsorgspenger() {
+        return omsorgspenger;
+    }
+
+    public BigDecimal getÅrForRefusjon() {
+        return årForRefusjon;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OmsorgspengerRefusjonPdfData that = (OmsorgspengerRefusjonPdfData) o;
+        return Objects.equals(avsenderSystem, that.avsenderSystem)
+            && Objects.equals(navnSøker, that.navnSøker)
+            && Objects.equals(personnummer, that.personnummer)
+            && Objects.equals(arbeidsgiverIdent, that.arbeidsgiverIdent)
+            && Objects.equals(arbeidsgiverNavn, that.arbeidsgiverNavn)
+            && Objects.equals(kontaktperson, that.kontaktperson)
+            && Objects.equals(månedInntekt, that.månedInntekt)
+            && Objects.equals(opprettetTidspunkt, that.opprettetTidspunkt)
+            && Objects.equals(endringsarsaker, that.endringsarsaker)
+            && Objects.equals(omsorgspenger, that.omsorgspenger)
+            && Objects.equals(årForRefusjon, that.årForRefusjon);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(avsenderSystem, navnSøker, personnummer, arbeidsgiverIdent, arbeidsgiverNavn, kontaktperson, månedInntekt,
+            opprettetTidspunkt, endringsarsaker,omsorgspenger, årForRefusjon);
+    }
+
+    public static String formaterPersonnummer(String personnummer) {
+        if (personnummer != null && personnummer.length() == 11) {
+            var formatertPersonnummer = new StringBuilder(personnummer);
+            formatertPersonnummer.insert(6, " ");
+            return formatertPersonnummer.toString();
+        }
+        return personnummer;
+    }
+
+    public static String formaterDatoForLister(LocalDate dato) {
+        if (dato == null) {
+            return null;
+        }
+        return dato.format(ofPattern("dd.MM.yyyy", Locale.forLanguageTag("NO")));
+    }
+
+    public static String formaterDatoMedNavnPåUkedag(LocalDate dato) {
+        if (dato == null) {
+            return null;
+        }
+        var navnPåUkedag = dato.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.forLanguageTag("NO"));
+        navnPåUkedag = navnPåUkedag.substring(0,1).toUpperCase() + navnPåUkedag.substring(1);
+        return navnPåUkedag + " " + dato.format(ofPattern("d. MMMM yyyy", Locale.forLanguageTag("NO")));
+    }
+
+    public static String formaterDatoOgTidNorsk(LocalDateTime opprettetTidspunkt) {
+        if (opprettetTidspunkt == null) {
+            return null;
+        }
+        return opprettetTidspunkt.format(ofPattern("d. MMMM yyyy HH:mm:ss", Locale.forLanguageTag("NO")));
+    }
+
+    public void anonymiser() {
+        this.personnummer = personnummer.substring(0, 4) + "** *****";
+        this.arbeidsgiverIdent = arbeidsgiverIdent.substring(0, 4) + "** *****";
+    }
+
+    public static class Builder {
+        private OmsorgspengerRefusjonPdfData kladd;
+
+        public Builder() {
+            kladd = new OmsorgspengerRefusjonPdfData();
+        }
+
+        public Builder medAvsenderSystem(String avsenderSystem) {
+            this.kladd.avsenderSystem = avsenderSystem;
+            return this;
+        }
+
+        public Builder medNavn(String navn) {
+            this.kladd.navnSøker = navn;
+            return this;
+        }
+
+        public Builder medPersonnummer(String personnummer) {
+            this.kladd.personnummer = formaterPersonnummer(personnummer);
+            return this;
+        }
+
+        public Builder medArbeidsgiverIdent(String arbeidsgiverIdent) {
+            this.kladd.arbeidsgiverIdent = arbeidsgiverIdent;
+            return this;
+        }
+
+        public Builder medArbeidsgiverNavn(String arbeidsgiverNavn) {
+            this.kladd.arbeidsgiverNavn = arbeidsgiverNavn;
+            return this;
+        }
+
+        public Builder medMånedInntekt(BigDecimal månedInntekt) {
+            this.kladd.månedInntekt = månedInntekt;
+            return this;
+        }
+
+        public Builder medOpprettetTidspunkt(LocalDateTime opprettetTidspunkt) {
+            this.kladd.opprettetTidspunkt = formaterDatoOgTidNorsk(opprettetTidspunkt);
+            return this;
+        }
+
+        public Builder medKontaktperson(Kontaktperson kontaktperson) {
+            this.kladd.kontaktperson = kontaktperson;
+            return this;
+        }
+
+        public Builder medEndringsårsaker(List<Endringsarsak> endringsårsaker) {
+            this.kladd.endringsarsaker = endringsårsaker;
+            return this;
+        }
+
+        public Builder medOmsorgspenger(Omsorgspenger omsorgspenger) {
+            this.kladd.omsorgspenger = omsorgspenger;
+            return this;
+        }
+
+        public Builder medÅrForRefusjon(BigDecimal årForRefusjon) {
+            this.kladd.årForRefusjon = årForRefusjon;
+            return this;
+        }
+
+        public OmsorgspengerRefusjonPdfData build() {
+            return kladd;
+        }
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfDataMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfDataMapper.java
@@ -1,0 +1,66 @@
+package no.nav.familie.inntektsmelding.integrasjoner.dokgen;
+
+import static no.nav.familie.inntektsmelding.integrasjoner.dokgen.InntektsmeldingPdfData.formaterDatoForLister;
+
+import java.math.BigDecimal;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import no.nav.familie.inntektsmelding.imdialog.modell.EndringsårsakEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
+
+public class OmsorgspengerRefusjonPdfDataMapper {
+
+    private OmsorgspengerRefusjonPdfDataMapper() {
+        throw new IllegalStateException("InntektsmeldingPdfDataMapper: Utility class");
+    }
+
+    public static OmsorgspengerRefusjonPdfData mapOmsorgspengerRefusjonData(InntektsmeldingEntitet inntektsmelding,
+                                                                String arbeidsgiverNavn,
+                                                                PersonInfo personInfo,
+                                                                String arbeidsgvierIdent) {
+        var startdato = inntektsmelding.getStartDato();
+        var imDokumentdataBuilder = new OmsorgspengerRefusjonPdfData.Builder()
+            .medNavn(personInfo.mapNavn())
+            .medPersonnummer(personInfo.fødselsnummer().getIdent())
+            .medArbeidsgiverIdent(arbeidsgvierIdent)
+            .medArbeidsgiverNavn(arbeidsgiverNavn)
+            .medAvsenderSystem("NAV_NO")
+            .medOpprettetTidspunkt(inntektsmelding.getOpprettetTidspunkt())
+            .medMånedInntekt(inntektsmelding.getMånedInntekt())
+            .medKontaktperson(mapKontaktperson(inntektsmelding))
+            .medEndringsårsaker(mapEndringsårsaker(inntektsmelding.getEndringsårsaker()))
+            .medOmsorgspenger(mapOmsorgspenger(inntektsmelding.getOmsorgspenger()))
+            .medÅrForRefusjon(BigDecimal.valueOf(startdato.getYear()));
+
+        return imDokumentdataBuilder.build();
+    }
+
+    private static Omsorgspenger mapOmsorgspenger(OmsorgspengerEntitet omsorgspenger) {
+        var datoFormat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+        var fraværsPerioder = omsorgspenger.getFraværsPerioder()
+            .stream()
+            .map(fp -> new Omsorgspenger.FraværsPeriode(fp.getPeriode().getFom().format(datoFormat), fp.getPeriode().getTom().format(datoFormat)))
+            .toList();
+
+        var delvisFraværsPerioder = omsorgspenger.getDelvisFraværsPerioder()
+            .stream()
+            .map(dfp -> new Omsorgspenger.DelvisFraværsPeriode(dfp.getDato().format(datoFormat), dfp.getTimer()))
+            .toList();
+
+        return new Omsorgspenger(omsorgspenger.isHarUtbetaltPliktigeDager(), fraværsPerioder, delvisFraværsPerioder);
+    }
+
+    private static List<Endringsarsak> mapEndringsårsaker(List<EndringsårsakEntitet> endringsårsaker) {
+        return endringsårsaker.stream()
+            .map( endringsårsakEntitet -> new Endringsarsak(endringsårsakEntitet.getÅrsak().getBeskrivelse(), formaterDatoForLister(endringsårsakEntitet.getFom().orElse(null)), formaterDatoForLister(endringsårsakEntitet.getTom().orElse(null)),
+                formaterDatoForLister(endringsårsakEntitet.getBleKjentFom().orElse(null))))
+            .toList();
+    }
+
+    private static Kontaktperson mapKontaktperson(InntektsmeldingEntitet inntektsmelding) {
+        return new Kontaktperson(inntektsmelding.getKontaktperson().getNavn(), inntektsmelding.getKontaktperson().getTelefonnummer());
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenKlientTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenKlientTest.java
@@ -17,7 +17,7 @@ class K9DokgenKlientTest {
 
     @Test
     void skal_generere_pdf() throws URISyntaxException {
-        K9DokgenKlient k9DokgenKlient = new K9DokgenKlient(restClient, "/path", "/path");
+        K9DokgenKlient k9DokgenKlient = new K9DokgenKlient(restClient);
         when(restClient.sendReturnByteArray(any())).thenReturn("pdf".getBytes());
         var bytes = k9DokgenKlient.genererPdf(new InntektsmeldingPdfData());
         assertThat(bytes).isNotEmpty();


### PR DESCRIPTION
### Bakgrunn
Vi har opprettet et nytt endepunkt for å generere pdf for omsorgspenger refusjon for å speile oppsummeringen til den flyten. Endringene i pdfen ble innlemmet her: https://github.com/navikt/k9-dokgen/pull/275

Tilhørende Jira: https://jira.adeo.no/browse/POFIM-204

### Løsning
- Oppretter eget pdf objekt for omsorgspenger refusjon og tar i bruk det nye endepunktet
- Fjerner omsorgspenger-data fra "vanlig" inntektsmelding-pdf

### Annet
Fjerner omsorgspenger fra "vanlig" inntektsmelding-pdf her: https://github.com/navikt/k9-dokgen/pull/276