### PR TITLE
Fiks merkelapp for omsorgspenger så det matcher den Fager har

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
@@ -2,7 +2,7 @@ package no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon;
 
 public enum Merkelapp {
     INNTEKTSMELDING_PSB("Inntektsmelding pleiepenger sykt barn"),
-    INNTEKTSMELDING_OMP("Refusjonskrav for omsorgspenger"),
+    INNTEKTSMELDING_OMP("nntektsmelding omsorgspenger"),
     INNTEKTSMELDING_PILS("Inntektsmelding pleiepenger i livets sluttfase"),
     INNTEKTSMELDING_OPP("Inntektsmelding opplæringspenger");
 

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
@@ -9,7 +9,7 @@ class MerkelappTest {
 
     @Test
     void getBeskrivelse() {
-        assertThat(Merkelapp.INNTEKTSMELDING_OMP.getBeskrivelse()).isEqualTo("Refusjonskrav for omsorgspenger");
+        assertThat(Merkelapp.INNTEKTSMELDING_OMP.getBeskrivelse()).isEqualTo("nntektsmelding omsorgspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_OPP.getBeskrivelse()).isEqualTo("Inntektsmelding opplæringspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_PILS.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger i livets sluttfase");
         assertThat(Merkelapp.INNTEKTSMELDING_PSB.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger sykt barn");


### PR DESCRIPTION
### Bakgrunn
Vi ønsker egentlig å markere saker for omsorgspenger med "Refusjonskrav omsorgspenger". Det viser seg at vi er nødt til å legge dette inn i team Fager sin liste over godkjente merkelapper. 

Nå feiler innsending pga merkelappen og hindrer videre testing. 

### Løsning
Bruker den godkjente merkelappen inntil den nye er lagt inn i Fager.