### PR TITLE
POFIM-204: Endrer merkelapp for oms til refusjonskrav for omsorgspenger

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
@@ -2,7 +2,7 @@ package no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon;
 
 public enum Merkelapp {
     INNTEKTSMELDING_PSB("Inntektsmelding pleiepenger sykt barn"),
-    INNTEKTSMELDING_OMP("Inntektsmelding omsorgspenger"),
+    INNTEKTSMELDING_OMP("Refusjonskrav for omsorgspenger"),
     INNTEKTSMELDING_PILS("Inntektsmelding pleiepenger i livets sluttfase"),
     INNTEKTSMELDING_OPP("Inntektsmelding opplæringspenger");
 

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
@@ -9,7 +9,7 @@ class MerkelappTest {
 
     @Test
     void getBeskrivelse() {
-        assertThat(Merkelapp.INNTEKTSMELDING_OMP.getBeskrivelse()).isEqualTo("Inntektsmelding omsorgspenger");
+        assertThat(Merkelapp.INNTEKTSMELDING_OMP.getBeskrivelse()).isEqualTo("Refusjonskrav for omsorgspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_OPP.getBeskrivelse()).isEqualTo("Inntektsmelding opplæringspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_PILS.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger i livets sluttfase");
         assertThat(Merkelapp.INNTEKTSMELDING_PSB.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger sykt barn");


### PR DESCRIPTION
Bakgrunn
Vi ønsker å markere saker for omsorgspenger med "Refusjonskrav omsorgspenger". Dette er nå lagt til i team Fager sin liste over godkjente merkelapper.

Løsning
Endrer merkelapp for omsorgspenger til "Refusjonskrav for omsorgspenger".