### PR TITLE
Endepunkt som henter alle im for ett gitt år

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
@@ -52,6 +52,18 @@ public class InntektsmeldingRepository {
         return query.getResultList();
     }
 
+    public List<InntektsmeldingEntitet> hentInntektsmeldingerForÅr(AktørIdEntitet aktørId, String arbeidsgiverIdent, int år, Ytelsetype ytelsetype) {
+        var query = entityManager.createQuery(
+                "FROM InntektsmeldingEntitet where aktørId = :brukerAktørId and ytelsetype = :ytelsetype and arbeidsgiverIdent = :arbeidsgiverIdent and EXTRACT(YEAR FROM startDato) = :år order by opprettetTidspunkt desc",
+                InntektsmeldingEntitet.class)
+            .setParameter("brukerAktørId", aktørId)
+            .setParameter("arbeidsgiverIdent", arbeidsgiverIdent)
+            .setParameter("ytelsetype", ytelsetype)
+            .setParameter("år", år);
+
+        return query.getResultList();
+    }
+
     public InntektsmeldingEntitet hentInntektsmelding(long inntektsmeldingId) {
         return entityManager.find(InntektsmeldingEntitet.class, inntektsmeldingId);
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -89,8 +89,8 @@ public class InntektsmeldingDialogRest {
     @Path(HENT_INNTEKTSMELDINGER_FOR_ÅR)
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @Tilgangskontrollert
-    public Response hentInntektsmeldingerForÅr(@NotNull @Valid AktørIdDto aktorId,
-                                               @NotNull @Valid ArbeidsgiverDto arbeidsgiverIdent,
+    public Response hentInntektsmeldingerForÅr(@NotNull @Valid @QueryParam("aktørId") AktørIdDto aktorId,
+                                               @NotNull @Valid @QueryParam("arbeidsgiverIdent") ArbeidsgiverDto arbeidsgiverIdent,
                                                @NotNull @Valid @QueryParam("år") int år) {
         tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(new OrganisasjonsnummerDto(arbeidsgiverIdent.ident()));
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -37,6 +37,7 @@ public class InntektsmeldingDialogRest {
     public static final String BASE_PATH = "/imdialog";
     private static final String HENT_OPPLYSNINGER = "/opplysninger";
     private static final String HENT_INNTEKTSMELDINGER_FOR_OPPGAVE = "/inntektsmeldinger";
+    private static final String HENT_INNTEKTSMELDINGER_FOR_ÅR = "/inntektsmeldinger-for-aar";
     private static final String SEND_INNTEKTSMELDING = "/send-inntektsmelding";
     private static final String SEND_INNTEKTSMELDING_OMS_REFUSJON = "/send-inntektsmelding/omsorgspenger-refusjon";
     private static final String LAST_NED_PDF = "/last-ned-pdf";
@@ -76,6 +77,18 @@ public class InntektsmeldingDialogRest {
 
         LOG.info("Henter inntektsmeldinger for forespørsel {}", forespørselUuid);
         var dto = inntektsmeldingTjeneste.hentInntektsmeldinger(forespørselUuid);
+        return Response.ok(dto).build();
+    }
+
+    @GET
+    @Path(HENT_INNTEKTSMELDINGER_FOR_ÅR)
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Tilgangskontrollert
+    public Response hentInntektsmeldingerForÅr(@NotNull @Valid @QueryParam("foresporselUuid") UUID forespørselUuid) {
+        tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(forespørselUuid);
+
+        LOG.info("Henter inntektsmeldinger for år for forespørsel {}", forespørselUuid);
+        var dto = inntektsmeldingTjeneste.hentInntektsmeldingerForÅr(forespørselUuid);
         return Response.ok(dto).build();
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -16,7 +16,12 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.AktørIdDto;
+import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,11 +89,18 @@ public class InntektsmeldingDialogRest {
     @Path(HENT_INNTEKTSMELDINGER_FOR_ÅR)
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @Tilgangskontrollert
-    public Response hentInntektsmeldingerForÅr(@NotNull @Valid @QueryParam("foresporselUuid") UUID forespørselUuid) {
-        tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(forespørselUuid);
+    public Response hentInntektsmeldingerForÅr(@NotNull @Valid AktørIdDto aktorId,
+                                               @NotNull @Valid ArbeidsgiverDto arbeidsgiverIdent,
+                                               @NotNull @Valid @QueryParam("år") int år) {
+        tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(new OrganisasjonsnummerDto(arbeidsgiverIdent.ident()));
 
-        LOG.info("Henter inntektsmeldinger for år for forespørsel {}", forespørselUuid);
-        var dto = inntektsmeldingTjeneste.hentInntektsmeldingerForÅr(forespørselUuid);
+        LOG.info("Henter inntektsmeldinger for år for organisasjon {}", arbeidsgiverIdent.ident());
+
+        // denne metoden vil kun bli brukt for omsorgspenger da de har fagsak som strekker seg over ett år
+        var dto = inntektsmeldingTjeneste.hentInntektsmeldingerForÅr(new AktørIdEntitet(aktorId.id()),
+            arbeidsgiverIdent.ident(),
+            år,
+            Ytelsetype.OMSORGSPENGER);
         return Response.ok(dto).build();
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -224,7 +224,24 @@ public class InntektsmeldingTjeneste {
         return inntektsmeldinger.stream().map(im -> InntektsmeldingMapper.mapFraEntitet(im, forespørsel.getUuid())).toList();
     }
 
-    public byte[] hentPDF(long id) {
+    public List<InntektsmeldingResponseDto> hentInntektsmeldingerForÅr(UUID forespørselUuid) {
+        var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
+            .orElseThrow(
+                () -> new IllegalStateException("Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
+
+        var år = forespørsel.getFørsteUttaksdato().orElseGet(forespørsel::getSkjæringstidspunkt).getYear();
+
+        var inntektsmeldinger = inntektsmeldingRepository.hentInntektsmeldingerForÅr(forespørsel.getAktørId(),
+            forespørsel.getOrganisasjonsnummer(),
+            år,
+            forespørsel.getYtelseType());
+
+        return inntektsmeldinger.stream()
+            .map(im -> InntektsmeldingMapper.mapFraEntitet(im, forespørsel.getUuid()))
+            .toList();
+    }
+
+        public byte[] hentPDF(long id) {
         var inntektsmeldingEntitet = inntektsmeldingRepository.hentInntektsmelding(id);
         return k9DokgenTjeneste.mapDataOgGenererPdf(inntektsmeldingEntitet);
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -229,10 +229,15 @@ public class InntektsmeldingTjeneste {
                                                                        int år,
                                                                        Ytelsetype ytelsetype) {
 
+        var forespørsler = forespørselBehandlingTjeneste.finnForespørsler(aktørId, ytelsetype, arbeidsgiverIdent);
+
+        // dersom det ikke finnes noen forespørsler er det ikke noe for GUI å vise
+        if (forespørsler.isEmpty()) {
+            return List.of();
+        }
+
         // da denne koden er kun for GUI så er det ikke så viktig at forespørsel stemmer
-        var førsteForespørsel = forespørselBehandlingTjeneste.finnForespørsler(aktørId, ytelsetype, arbeidsgiverIdent).stream().findFirst()
-            .orElseThrow(
-                () -> new IllegalStateException("Prøver å hente en forespørsel som ikke finnes, for orgNr: " + arbeidsgiverIdent));
+        var førsteForespørsel = forespørsler.stream().findFirst();
 
         var inntektsmeldinger = inntektsmeldingRepository.hentInntektsmeldingerForÅr(aktørId,
             arbeidsgiverIdent,
@@ -240,7 +245,7 @@ public class InntektsmeldingTjeneste {
             ytelsetype);
 
         return inntektsmeldinger.stream()
-            .map(im -> InntektsmeldingMapper.mapFraEntitet(im, førsteForespørsel.getUuid()))
+            .map(im -> InntektsmeldingMapper.mapFraEntitet(im, førsteForespørsel.get().getUuid()))
             .toList();
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -224,20 +224,23 @@ public class InntektsmeldingTjeneste {
         return inntektsmeldinger.stream().map(im -> InntektsmeldingMapper.mapFraEntitet(im, forespørsel.getUuid())).toList();
     }
 
-    public List<InntektsmeldingResponseDto> hentInntektsmeldingerForÅr(UUID forespørselUuid) {
-        var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
+    public List<InntektsmeldingResponseDto> hentInntektsmeldingerForÅr(AktørIdEntitet aktørId,
+                                                                       String arbeidsgiverIdent,
+                                                                       int år,
+                                                                       Ytelsetype ytelsetype) {
+
+        // da denne koden er kun for GUI så er det ikke så viktig at forespørsel stemmer
+        var førsteForespørsel = forespørselBehandlingTjeneste.finnForespørsler(aktørId, ytelsetype, arbeidsgiverIdent).stream().findFirst()
             .orElseThrow(
-                () -> new IllegalStateException("Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
+                () -> new IllegalStateException("Prøver å hente en forespørsel som ikke finnes, for orgNr: " + arbeidsgiverIdent));
 
-        var år = forespørsel.getFørsteUttaksdato().orElseGet(forespørsel::getSkjæringstidspunkt).getYear();
-
-        var inntektsmeldinger = inntektsmeldingRepository.hentInntektsmeldingerForÅr(forespørsel.getAktørId(),
-            forespørsel.getOrganisasjonsnummer(),
+        var inntektsmeldinger = inntektsmeldingRepository.hentInntektsmeldingerForÅr(aktørId,
+            arbeidsgiverIdent,
             år,
-            forespørsel.getYtelseType());
+            ytelsetype);
 
         return inntektsmeldinger.stream()
-            .map(im -> InntektsmeldingMapper.mapFraEntitet(im, forespørsel.getUuid()))
+            .map(im -> InntektsmeldingMapper.mapFraEntitet(im, førsteForespørsel.getUuid()))
             .toList();
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepositoryTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepositoryTest.java
@@ -358,5 +358,83 @@ class InntektsmeldingRepositoryTest extends EntityManagerAwareTest {
         assertThat(etterLagring.get(1).getKontaktperson().getNavn()).isEqualTo(im1.getKontaktperson().getNavn());
     }
 
+    @Test
+    void skal_hente_alle_im_for_ett_gitt_år() {
+        // Arrange
+        var aktørId = new AktørIdEntitet("9999999999999");
+        var arbeidsgiverIdent = "999999999";
+        var startDato2025 = LocalDate.now();
+        var startDato2024 = LocalDate.now().minusYears(1);
+
+        var im1 = InntektsmeldingEntitet.builder()
+            .medAktørId(aktørId)
+            .medKontaktperson(new KontaktpersonEntitet("Første", "999999999"))
+            .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medMånedInntekt(BigDecimal.valueOf(4000))
+            .medMånedRefusjon(BigDecimal.valueOf(4000))
+            .medRefusjonOpphørsdato(Tid.TIDENES_ENDE)
+            .medStartDato(startDato2025)
+            .medRefusjonsendringer(Collections.singletonList(new RefusjonsendringEntitet(startDato2025.plusDays(10), BigDecimal.valueOf(2000))))
+            .medArbeidsgiverIdent(arbeidsgiverIdent)
+            .medOpprettetTidspunkt(LocalDateTime.now().plusDays(1))
+            .build();
+
+        var im2 = InntektsmeldingEntitet.builder()
+            .medAktørId(aktørId)
+            .medKontaktperson(new KontaktpersonEntitet("Andre", "999999999"))
+            .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medMånedInntekt(BigDecimal.valueOf(4000))
+            .medMånedRefusjon(BigDecimal.valueOf(4000))
+            .medRefusjonOpphørsdato(Tid.TIDENES_ENDE)
+            .medStartDato(startDato2025)
+            .medRefusjonsendringer(Collections.singletonList(new RefusjonsendringEntitet(startDato2025.plusDays(10), BigDecimal.valueOf(2000))))
+            .medArbeidsgiverIdent(arbeidsgiverIdent)
+            .medOpprettetTidspunkt(LocalDateTime.now().plusDays(2))
+            .build();
+
+        var im3RiktigÅrMenAnnenAktørId = InntektsmeldingEntitet.builder()
+            .medAktørId(new AktørIdEntitet("1234567891111"))
+            .medKontaktperson(new KontaktpersonEntitet("Tredje", "999999999"))
+            .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medMånedInntekt(BigDecimal.valueOf(4000))
+            .medMånedRefusjon(BigDecimal.valueOf(4000))
+            .medRefusjonOpphørsdato(Tid.TIDENES_ENDE)
+            .medStartDato(startDato2025)
+            .medRefusjonsendringer(Collections.singletonList(new RefusjonsendringEntitet(startDato2025.plusDays(10), BigDecimal.valueOf(2000))))
+            .medArbeidsgiverIdent(arbeidsgiverIdent)
+            .medOpprettetTidspunkt(LocalDateTime.now().plusDays(3))
+            .build();
+
+        var im4i2024 = InntektsmeldingEntitet.builder()
+            .medAktørId(aktørId)
+            .medKontaktperson(new KontaktpersonEntitet("Fjerde", "999999999"))
+            .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medMånedInntekt(BigDecimal.valueOf(4000))
+            .medMånedRefusjon(BigDecimal.valueOf(4000))
+            .medRefusjonOpphørsdato(Tid.TIDENES_ENDE)
+            .medStartDato(startDato2024)
+            .medRefusjonsendringer(Collections.singletonList(new RefusjonsendringEntitet(startDato2024.plusDays(10), BigDecimal.valueOf(2000))))
+            .medArbeidsgiverIdent(arbeidsgiverIdent)
+            .medOpprettetTidspunkt(LocalDateTime.now().minusYears(1).plusDays(4))
+            .build();
+
+        // Act
+        inntektsmeldingRepository.lagreInntektsmelding(im1);
+        inntektsmeldingRepository.lagreInntektsmelding(im2);
+        inntektsmeldingRepository.lagreInntektsmelding(im3RiktigÅrMenAnnenAktørId);
+        inntektsmeldingRepository.lagreInntektsmelding(im4i2024);
+
+        var etterLagring = inntektsmeldingRepository.hentInntektsmeldingerForÅr(aktørId, arbeidsgiverIdent, 2025, Ytelsetype.OMSORGSPENGER);
+
+        // Assert
+        assertThat(etterLagring).hasSize(2);
+        assertThat(etterLagring.getFirst().getStartDato().getYear()).isEqualTo(2025);
+        assertThat(etterLagring.getFirst().getAktørId()).isEqualTo(aktørId);
+        assertThat(etterLagring.getFirst().getArbeidsgiverIdent()).isEqualTo(arbeidsgiverIdent);
+        assertThat(etterLagring.getLast().getStartDato().getYear()).isEqualTo(2025);
+        assertThat(etterLagring.getLast().getAktørId()).isEqualTo(aktørId);
+        assertThat(etterLagring.getLast().getArbeidsgiverIdent()).isEqualTo(arbeidsgiverIdent);
+    }
+
 
 }


### PR DESCRIPTION
### Bakgrunn
Når arbeidsgiver skal fylle ut sitt refusjonskrav for en gitt aktør vet ikke vedkommende hva hen har sendt inn tidligere. Vi ønsker derfor en oversikt over alle tidligere innsendte inntektsmeldinger.

Jira: https://jira.adeo.no/browse/POFIM-213

### Løsning
Lager et endepunkt som henter ut alle inntektsmeldinger for en arbeidsgiver og dens ansatte og det aktuelle året.
Lager også en ny repository-metode som henter ut inntektsmeldingene gitt året som er angitt i startDato for kravet.