### PR TITLE
Legg til pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+### **Behov / Bakgrunn**
+
+
+### **Løsning**
+
+
+### **Andre endringer**
+
+
+### **Skjermbilder** (hvis relevant)


### PR DESCRIPTION
### Bakgrunn
For å senke terskelen for å dokumentere hvorfor man gjør endringer, hva endringen går ut på og måten man har løst det på, har vi bestemt oss for å legge til en template for pull requester med overskrifter som gir konteksten som vi ønsker.
