### PR TITLE
POFIM-216 Legger til perioder i tilleggsinfo for refusjonskrav omsorgspenger

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -406,13 +406,6 @@ public class ForespørselBehandlingTjeneste {
             .max(Comparator.comparing(f -> f.getFørsteUttaksdato().orElse(f.getSkjæringstidspunkt())));
     }
 
-    private void validerStartdato(ForespørselEntitet forespørsel, LocalDate startdato) {
-        var datoÅMatcheMot = forespørsel.getFørsteUttaksdato().orElseGet(forespørsel::getSkjæringstidspunkt);
-        if (!datoÅMatcheMot.equals(startdato)) {
-            throw new IllegalStateException("Startdato var ikke like");
-        }
-    }
-
     private void validerOrganisasjon(ForespørselEntitet forespørsel, OrganisasjonsnummerDto orgnummer) {
         if (!forespørsel.getOrganisasjonsnummer().equals(orgnummer.orgnr())) {
             throw new IllegalStateException("Organisasjonsnummer var ikke like");

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -12,6 +12,9 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,20 +73,28 @@ public class ForespørselBehandlingTjeneste {
     public ForespørselEntitet ferdigstillForespørsel(UUID foresporselUuid,
                                                      AktørIdEntitet aktorId,
                                                      OrganisasjonsnummerDto organisasjonsnummerDto,
-                                                     LocalDate startdato,
-                                                     LukkeÅrsak årsak) {
+                                                     LukkeÅrsak årsak,
+                                                     List<FraværsPeriodeEntitet> fraværsPerioder,
+                                                     List<DelvisFraværsPeriodeEntitet> delvisFraværDag) {
         var foresporsel = forespørselTjeneste.hentForespørsel(foresporselUuid)
             .orElseThrow(() -> new IllegalStateException("Finner ikke forespørsel for inntektsmelding, ugyldig tilstand"));
 
         validerAktør(foresporsel, aktorId);
         validerOrganisasjon(foresporsel, organisasjonsnummerDto);
-        validerStartdato(foresporsel, startdato);
 
         // Arbeidsgiverinitierte forespørsler har ingen oppgave
         foresporsel.getOppgaveId().ifPresent(oppgaveId -> arbeidsgiverNotifikasjon.oppgaveUtført(oppgaveId, OffsetDateTime.now()));
 
-        var erOmsorgspengerRefusjon = foresporsel.getOppgaveId().isEmpty();
+        var erOmsorgspengerRefusjon = foresporsel.getYtelseType().equals(Ytelsetype.OMSORGSPENGER);
         arbeidsgiverNotifikasjon.ferdigstillSak(foresporsel.getArbeidsgiverNotifikasjonSakId(), erOmsorgspengerRefusjon); // Oppdaterer status i arbeidsgiver-notifikasjon
+
+        String tilleggsinformasjon;
+        if (erOmsorgspengerRefusjon) {
+            tilleggsinformasjon = ForespørselTekster.lagTilleggsInformasjonForOmsorgspengerRefusjon(fraværsPerioder, delvisFraværDag);
+        } else {
+            tilleggsinformasjon = ForespørselTekster.lagTilleggsInformasjon(årsak, foresporsel.getSkjæringstidspunkt());
+        }
+        arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(foresporsel.getArbeidsgiverNotifikasjonSakId(), tilleggsinformasjon);
         arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(foresporsel.getArbeidsgiverNotifikasjonSakId(),
             ForespørselTekster.lagTilleggsInformasjon(årsak, foresporsel.getSkjæringstidspunkt()));
         forespørselTjeneste.ferdigstillForespørsel(foresporsel.getArbeidsgiverNotifikasjonSakId()); // Oppdaterer status i forespørsel
@@ -328,8 +339,7 @@ public class ForespørselBehandlingTjeneste {
             var lukketForespørsel = ferdigstillForespørsel(f.getUuid(),
                 f.getAktørId(),
                 new OrganisasjonsnummerDto(f.getOrganisasjonsnummer()),
-                f.getFørsteUttaksdato().orElseGet(f::getSkjæringstidspunkt),
-                LukkeÅrsak.EKSTERN_INNSENDING);
+                LukkeÅrsak.EKSTERN_INNSENDING, List.of(), List.of());
             MetrikkerTjeneste.loggForespørselLukkEkstern(lukketForespørsel);
         });
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -86,7 +86,7 @@ public class InntektsmeldingTjeneste {
         var entitet = InntektsmeldingMapper.mapTilEntitet(mottattInntektsmeldingDto, forespørselEntitet);
         var imId = lagreOgLagJournalførTask(entitet, forespørselEntitet);
         var lukketForespørsel = forespørselBehandlingTjeneste.ferdigstillForespørsel(mottattInntektsmeldingDto.foresporselUuid(), aktorId, orgnummer,
-            mottattInntektsmeldingDto.startdato(), LukkeÅrsak.ORDINÆR_INNSENDING);
+            LukkeÅrsak.ORDINÆR_INNSENDING, List.of(), List.of());
 
         var imEntitet = inntektsmeldingRepository.hentInntektsmelding(imId);
 
@@ -118,7 +118,7 @@ public class InntektsmeldingTjeneste {
         var imId = lagreOgLagJournalførTask(imEnitet, forespørselEnitet);
 
         forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid, aktørId, organisasjonsnummer,
-            sendInntektsmeldingRequestDto.startdato(), LukkeÅrsak.ORDINÆR_INNSENDING);
+            LukkeÅrsak.ORDINÆR_INNSENDING, imEnitet.getOmsorgspenger().getFraværsPerioder(), imEnitet.getOmsorgspenger().getDelvisFraværsPerioder());
 
         var imEntitet = inntektsmeldingRepository.hentInntektsmelding(imId);
 

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
@@ -112,8 +112,9 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
         forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid,
             new AktørIdEntitet(AKTØR_ID),
             new OrganisasjonsnummerDto(BRREG_ORGNUMMER),
-            SKJÆRINGSTIDSPUNKT,
-            LukkeÅrsak.EKSTERN_INNSENDING);
+            LukkeÅrsak.EKSTERN_INNSENDING,
+            List.of(),
+            List.of());
 
         clearHibernateCache();
 
@@ -130,8 +131,9 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
         forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid,
             new AktørIdEntitet(AKTØR_ID),
             new OrganisasjonsnummerDto(BRREG_ORGNUMMER),
-            FØRSTE_UTTAKSDATO,
-            LukkeÅrsak.EKSTERN_INNSENDING);
+            LukkeÅrsak.EKSTERN_INNSENDING,
+            List.of(),
+            List.of());
 
         clearHibernateCache();
 

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
@@ -3,8 +3,15 @@ package no.nav.familie.inntektsmelding.forespørsel.tjenester;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
+
+import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +52,27 @@ class ForespørselTeksterTest {
         LocalDate førsteFraværsdag = LocalDate.now();
         String statusTekst = ForespørselTekster.lagTilleggsInformasjon(LukkeÅrsak.ORDINÆR_INNSENDING, førsteFraværsdag);
         var forventetTekst = String.format("For første fraværsdag %s", førsteFraværsdag.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
+        assertEquals(forventetTekst, statusTekst);
+    }
+
+    @Test
+    void lagTilleggsInformasjon_OmsorgspengerRefusjon() {
+        List<FraværsPeriodeEntitet> fraværsPerioder = List.of(
+            new FraværsPeriodeEntitet(PeriodeEntitet.fraOgMedTilOgMed(LocalDate.now().minusDays(8), LocalDate.now().minusDays(6))),
+            new FraværsPeriodeEntitet(PeriodeEntitet.fraOgMedTilOgMed(LocalDate.now().minusDays(4), LocalDate.now().minusDays(2))));
+        List<DelvisFraværsPeriodeEntitet> delvisFravær = List.of(
+            new DelvisFraværsPeriodeEntitet(LocalDate.now().minusDays(10), BigDecimal.valueOf(2)),
+            new DelvisFraværsPeriodeEntitet(LocalDate.now().minusDays(1), BigDecimal.valueOf(4)));
+        String statusTekst = ForespørselTekster.lagTilleggsInformasjonForOmsorgspengerRefusjon(fraværsPerioder, delvisFravær);
+        var forventetTekst = String.format("For %s, %s, %s, %s, %s, %s, %s, %s.",
+            delvisFravær.getFirst().getDato().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
+            fraværsPerioder.getFirst().getPeriode().getFom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
+            fraværsPerioder.getFirst().getPeriode().getFom().plusDays(1).format(DateTimeFormatter.ofPattern("dd.MM.yy")),
+            fraværsPerioder.getFirst().getPeriode().getTom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
+            fraværsPerioder.getLast().getPeriode().getFom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
+            fraværsPerioder.getLast().getPeriode().getFom().plusDays(1).format(DateTimeFormatter.ofPattern("dd.MM.yy")),
+            fraværsPerioder.getLast().getPeriode().getTom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
+            delvisFravær.getLast().getDato().format(DateTimeFormatter.ofPattern("dd.MM.yy")));
         assertEquals(forventetTekst, statusTekst);
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Hver inntektsmelding på "min side arbeidsgiver" viser startdato for kravet. Dette gir lite informasjon for refusjonskrav omsorgspenger da det som regel søkes for flere perioder og enkeltdager. Vil vil derfor endre tilleggsinfo til å vise periodene og enkeltdagene oppramset, som for eksempel slik: "For 01.04.25, 02.04.25." etc.

Jira: https://jira.adeo.no/browse/POFIM-216

### **Løsning**
Sender derfor med fraværsperiodene og fraværsdagene i stedet for startdato/skjæringstidspunkt til generering av teksten som kalles tilleggsinfo.
Kutter deretter opp periodene i enkeltdager og legger de i én liste sammen med enkeltdagene (delvis fravær) og sorterer de kronologisk.
