### PR TITLE
POFIM-213 Finner alle forespørsler i stedet for kun under behandling

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -129,12 +129,22 @@ public class ForespørselRepository {
         return query.getResultList();
     }
 
-    public List<ForespørselEntitet> finnForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
+    public List<ForespørselEntitet> finnForespørslerUnderBehandling(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
         var query = entityManager.createQuery("FROM ForespørselEntitet where aktørId=:aktørId "
                     + "and status=:underBehandling and ytelseType=:ytelseType and organisasjonsnummer=:orgnr",
                 ForespørselEntitet.class)
             .setParameter("aktørId", aktørId)
             .setParameter("underBehandling", ForespørselStatus.UNDER_BEHANDLING)
+            .setParameter("ytelseType", ytelsetype)
+            .setParameter("orgnr", orgnr);
+        return query.getResultList();
+    }
+
+    public List<ForespørselEntitet> finnAlleForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
+        var query = entityManager.createQuery("FROM ForespørselEntitet where aktørId=:aktørId "
+                    + "and ytelseType=:ytelseType and organisasjonsnummer=:orgnr",
+                ForespørselEntitet.class)
+            .setParameter("aktørId", aktørId)
             .setParameter("ytelseType", ytelsetype)
             .setParameter("orgnr", orgnr);
         return query.getResultList();

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -105,8 +105,12 @@ public class ForespørselBehandlingTjeneste {
         return forespørselTjeneste.hentForespørsel(forespørselUUID);
     }
 
-    public List<ForespørselEntitet> finnForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
-        return forespørselTjeneste.finnForespørsler(aktørId, ytelsetype, orgnr);
+    public List<ForespørselEntitet> finnForespørslerUnderBehandling(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
+        return forespørselTjeneste.finnForespørslerUnderBehandling(aktørId, ytelsetype, orgnr);
+    }
+
+    public List<ForespørselEntitet> finnAlleForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
+        return forespørselTjeneste.finnAlleForespørsler(aktørId, ytelsetype, orgnr);
     }
 
     public void oppdaterForespørsler(Ytelsetype ytelsetype,

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -80,7 +80,11 @@ public class ForespørselTjeneste {
         return forespørselRepository.hentForespørsler(saksnummer);
     }
 
-    public List<ForespørselEntitet> finnForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
-        return forespørselRepository.finnForespørsler(aktørId, ytelsetype, orgnr);
+    public List<ForespørselEntitet> finnForespørslerUnderBehandling(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
+        return forespørselRepository.finnForespørslerUnderBehandling(aktørId, ytelsetype, orgnr);
+    }
+
+    public List<ForespørselEntitet> finnAlleForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
+        return forespørselRepository.finnAlleForespørsler(aktørId, ytelsetype, orgnr);
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -175,7 +175,7 @@ public class InntektsmeldingTjeneste {
                                                                      OrganisasjonsnummerDto organisasjonsnummer) {
         var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer, ytelsetype);
 
-        var eksisterendeForepørsler = forespørselBehandlingTjeneste.finnForespørsler(personInfo.aktørId(), ytelsetype, organisasjonsnummer.orgnr());
+        var eksisterendeForepørsler = forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(personInfo.aktørId(), ytelsetype, organisasjonsnummer.orgnr());
         var forespørslerSomMatcherFraværsdag = eksisterendeForepørsler.stream()
             .filter(f -> førsteFraværsdag.equals(f.getFørsteUttaksdato().orElse(f.getSkjæringstidspunkt()))) // TODO: sjekk for et større intervall etterhvert
             .toList();
@@ -229,7 +229,7 @@ public class InntektsmeldingTjeneste {
                                                                        int år,
                                                                        Ytelsetype ytelsetype) {
 
-        var forespørsler = forespørselBehandlingTjeneste.finnForespørsler(aktørId, ytelsetype, arbeidsgiverIdent);
+        var forespørsler = forespørselBehandlingTjeneste.finnAlleForespørsler(aktørId, ytelsetype, arbeidsgiverIdent);
 
         LOG.info("Fant antall forespørsler: " + forespørsler.size());
         LOG.info("ForespørselUuid: " + forespørsler.stream().map(ForespørselEntitet::getUuid).toList());

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
@@ -280,7 +280,7 @@ class InntektsmeldingTjenesteTest {
         when(personTjeneste.hentPersonFraIdent(fødselsnummer, ytelsetype)).thenReturn(personInfo);
         when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID), ytelsetype)).thenReturn(
             new PersonInfo("Ine", null, "Sender", new PersonIdent(INNMELDER_UID), null, LocalDate.now(), "+4711111111"));
-        when(forespørselBehandlingTjeneste.finnForespørsler(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of(forespørsel));
+        when(forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of(forespørsel));
         when(organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer.orgnr())).thenReturn(new Organisasjon("Bedriften",
             organisasjonsnummer.orgnr()));
         when(inntektTjeneste.hentInntekt(aktørId,
@@ -318,7 +318,7 @@ class InntektsmeldingTjenesteTest {
         when(personTjeneste.hentPersonInfoFraAktørId(aktørId, ytelsetype)).thenReturn(personInfo);
         when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID), ytelsetype)).thenReturn(
             new PersonInfo("Ine", null, "Sender", new PersonIdent(INNMELDER_UID), null, LocalDate.now(), "+4711111111"));
-        when(forespørselBehandlingTjeneste.finnForespørsler(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of(forespørsel));
+        when(forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of(forespørsel));
         when(forespørselBehandlingTjeneste.hentForespørsel(forespørsel.getUuid())).thenReturn(Optional.of(forespørsel));
         when(organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer.orgnr())).thenReturn(new Organisasjon("Bedriften",
             organisasjonsnummer.orgnr()));


### PR DESCRIPTION
### **Behov / Bakgrunn**
Metoden `finnForespørsler` hentet egentlig kun de som er under behandling. Vi ønsker alle uansett status.

### **Løsning**
Renamet `finnForespørsler` til `finnForespørslerUnderBehandling` og laget en ny metode som heter `finnAlleForespørsler`.

