### PR TITLE
POFIM-212: Legg til endepunkt i swagger for å telle antall inntektsmeldinger som ikke har en forespørsel

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/ForespørselForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/ForespørselForvaltningRestTjeneste.java
@@ -1,15 +1,5 @@
 package no.nav.familie.inntektsmelding.forvaltning;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -20,20 +10,24 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
 
 @AutentisertMedAzure
-@OpenAPIDefinition(tags = @Tag(name = "Inntektsmelding", description = "Undersøk om alle inntektsmeldinger er knyttet til en forespørsel",))
+@OpenAPIDefinition(tags = @Tag(name = "Inntektsmelding", description = "Undersøk om alle inntektsmeldinger er knyttet til en forespørsel"))
 @RequestScoped
 @Transactional
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/inntektsmelding")
 public class ForespørselForvaltningRestTjeneste {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ForespørselForvaltningRestTjeneste.class);
 
     private Tilgang tilgang;
     private InntektsmeldingRepository inntektsmeldingRepository;

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/ForespørselForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/ForespørselForvaltningRestTjeneste.java
@@ -1,0 +1,75 @@
+package no.nav.familie.inntektsmelding.forvaltning;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
+import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
+import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
+import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
+
+@AutentisertMedAzure
+@OpenAPIDefinition(tags = @Tag(name = "Inntektsmelding", description = "Undersøk om alle inntektsmeldinger er knyttet til en forespørsel",))
+@RequestScoped
+@Transactional
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/inntektsmelding")
+public class ForespørselForvaltningRestTjeneste {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForespørselForvaltningRestTjeneste.class);
+
+    private Tilgang tilgang;
+    private InntektsmeldingRepository inntektsmeldingRepository;
+
+    ForespørselForvaltningRestTjeneste() {
+        // REST CDI
+    }
+
+    @Inject
+    public ForespørselForvaltningRestTjeneste(Tilgang tilgang, InntektsmeldingRepository inntektsmeldingRepository) {
+        this.tilgang = tilgang;
+        this.inntektsmeldingRepository = inntektsmeldingRepository;
+    }
+
+    @POST
+    @Path("/im-uten-forespørsel")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+        description = "Finn antall inntektsmeldinger som ikker har en forespørsel",
+        summary = "Finn antall inntektsmeldinger som ikker har en forespørsel",
+        tags = "oppgaver",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "Gir antall inntektsmeldinger som ikke har en forespørsel",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
+        })
+    @Tilgangskontrollert
+    public Response erAlleInntektsmeldingKnyttetTilEnForespørsel() {
+        sjekkAtKallerHarRollenDrift();
+
+        var resultat = inntektsmeldingRepository.antallInntektsmeldingerUtenForespørsel();
+
+        return Response.ok(resultat).build();
+    }
+
+    private void sjekkAtKallerHarRollenDrift() {
+        tilgang.sjekkAtAnsattHarRollenDrift();
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
@@ -67,4 +67,12 @@ public class InntektsmeldingRepository {
     public InntektsmeldingEntitet hentInntektsmelding(long inntektsmeldingId) {
         return entityManager.find(InntektsmeldingEntitet.class, inntektsmeldingId);
     }
+
+    public Long antallInntektsmeldingerUtenForespørsel() {
+        var query = entityManager.createQuery(
+            "SELECT COUNT(inntektsmelding) FROM InntektsmeldingEntitet inntektsmelding WHERE inntektsmelding.forespørsel IS NULL",
+            Long.class);
+
+        return (Long) query.getSingleResult();
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/server/app/forvaltning/ForvaltningApiConfig.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/server/app/forvaltning/ForvaltningApiConfig.java
@@ -10,9 +10,6 @@ import java.util.stream.Collectors;
 
 import jakarta.ws.rs.ApplicationPath;
 
-import no.nav.familie.inntektsmelding.forvaltning.ForespørselForvaltningRestTjeneste;
-import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingDialogRest;
-
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import org.slf4j.Logger;
@@ -24,6 +21,7 @@ import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import no.nav.familie.inntektsmelding.forvaltning.ForespørselForvaltningRestTjeneste;
 import no.nav.familie.inntektsmelding.forvaltning.K9DokgenRestTjeneste;
 import no.nav.familie.inntektsmelding.forvaltning.OppgaverForvaltningRestTjeneste;
 import no.nav.familie.inntektsmelding.forvaltning.ProsessTaskRestTjeneste;
@@ -72,9 +70,9 @@ public class ForvaltningApiConfig extends ResourceConfig {
         var oas = new OpenAPI();
         var info = new Info().title(ENV.getNaisAppName())
             .version(Optional.ofNullable(ENV.imageName()).orElse("1.0"))
-            .description("REST grensesnitt for fp-inntektsmelding.");
+            .description("REST grensesnitt for k9-inntektsmelding.");
 
-        oas.info(info).addServersItem(new Server().url(ENV.getProperty("context.path", "/fpinntektsmelding")));
+        oas.info(info).addServersItem(new Server().url(ENV.getProperty("context.path", "/k9-inntektsmelding")));
         var oasConfig = new SwaggerConfiguration().openAPI(oas)
             .prettyPrint(true)
             .resourceClasses(getApplicationClasses().stream().map(Class::getName).collect(Collectors.toSet()));
@@ -92,7 +90,6 @@ public class ForvaltningApiConfig extends ResourceConfig {
         classes.add(ProsessTaskRestTjeneste.class);
         classes.add(K9DokgenRestTjeneste.class);
         classes.add(OppgaverForvaltningRestTjeneste.class);
-        classes.add(InntektsmeldingDialogRest.class);
         classes.add(ForespørselForvaltningRestTjeneste.class);
         if (Environment.current().isLocal()) {
             classes.add(ForespørselVtpRest.class);

--- a/src/main/java/no/nav/familie/inntektsmelding/server/app/forvaltning/ForvaltningApiConfig.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/server/app/forvaltning/ForvaltningApiConfig.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import jakarta.ws.rs.ApplicationPath;
 
+import no.nav.familie.inntektsmelding.forvaltning.ForespørselForvaltningRestTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingDialogRest;
 
 import org.glassfish.jersey.server.ResourceConfig;
@@ -92,6 +93,7 @@ public class ForvaltningApiConfig extends ResourceConfig {
         classes.add(K9DokgenRestTjeneste.class);
         classes.add(OppgaverForvaltningRestTjeneste.class);
         classes.add(InntektsmeldingDialogRest.class);
+        classes.add(ForespørselForvaltningRestTjeneste.class);
         if (Environment.current().isLocal()) {
             classes.add(ForespørselVtpRest.class);
         }


### PR DESCRIPTION
### **Behov / Bakgrunn**
I utgangspunktet burde alle inntektsmeldinger være tilknyttet en forespørsel. Vi ønsker derfor å kjøre et migreringsscript som setter kolonnen `forespoersel_id` i InntektsmeldingEntitet til `not null`, men vi må undersøke om det faktisk stemmer så ikke flyway kræsjer. 

Relevant PR: https://github.com/navikt/k9-inntektsmelding/pull/425
Jira: https://jira.adeo.no/browse/POFIM-212

### **Løsning**
Legger til et swagger endepunkt som teller antall inntektsmeldinger som har `forespoersel_id = null`. Ved å gjøre det gjennom swagger får vi med begrunnelse for hvorfor man har kikket på data i prod, som er fint selv om det ikke er noe sensitiv data i denne spørringen. 

### **Andre endringer**
Fjerner InntektsmeldingDialogRest fra swagger som ikke brukes.
