### PR TITLE
POFIM-216 Endrer tekst fra enkeltdatoer til antall i hver måned

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
@@ -1,11 +1,14 @@
 package no.nav.familie.inntektsmelding.forespørsel.tjenester;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
@@ -47,11 +50,40 @@ class ForespørselTekster {
     public static String lagTilleggsInformasjonForOmsorgspengerRefusjon(List<FraværsPeriodeEntitet> fraværsPerioder,
                                                                         List<DelvisFraværsPeriodeEntitet> delvisFraværDag) {
         List<LocalDate> fravær = sammenstillFravær(fraværsPerioder, delvisFraværDag);
-        return String.format(TILLEGGSINFORMASJON_OMS_REFUSJON,
-            fravær
+
+        Map<Month, Long> fraværPerMåned = fravær
             .stream()
-            .map(date -> date.format(DateTimeFormatter.ofPattern("dd.MM.yy")))
+            .collect(Collectors.groupingBy(Month::from, Collectors.counting()));
+
+        Map<Month, String> månederPåNorskOgEngelsk = månederFraEngelskTilNorsk();
+
+        return String.format(TILLEGGSINFORMASJON_OMS_REFUSJON,
+            fraværPerMåned
+            .entrySet()
+            .stream()
+            .map(måned -> String.format("%s %s i %s", måned.getValue(), dagEllerDager(måned.getValue()), månederPåNorskOgEngelsk.get(måned.getKey())))
             .collect(Collectors.joining(", ")));
+    }
+
+    private static String dagEllerDager(long antallDager) {
+        return antallDager == 1 ? "dag" : "dager";
+    }
+
+    private static Map<Month, String> månederFraEngelskTilNorsk() {
+        Map<Month, String> månederPåNorskOgEngelsk = new HashMap<>();
+        månederPåNorskOgEngelsk.put(Month.JANUARY, "januar");
+        månederPåNorskOgEngelsk.put(Month.FEBRUARY, "februar");
+        månederPåNorskOgEngelsk.put(Month.MARCH, "mars");
+        månederPåNorskOgEngelsk.put(Month.APRIL, "april");
+        månederPåNorskOgEngelsk.put(Month.MAY, "mai");
+        månederPåNorskOgEngelsk.put(Month.JUNE, "juni");
+        månederPåNorskOgEngelsk.put(Month.JULY, "juli");
+        månederPåNorskOgEngelsk.put(Month.AUGUST, "august");
+        månederPåNorskOgEngelsk.put(Month.SEPTEMBER, "september");
+        månederPåNorskOgEngelsk.put(Month.OCTOBER, "oktober");
+        månederPåNorskOgEngelsk.put(Month.NOVEMBER, "november");
+        månederPåNorskOgEngelsk.put(Month.DECEMBER, "desember");
+        return månederPåNorskOgEngelsk;
     }
 
     private static List<LocalDate> sammenstillFravær(List<FraværsPeriodeEntitet> fraværsPerioder,

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
@@ -58,21 +58,13 @@ class ForespørselTeksterTest {
     @Test
     void lagTilleggsInformasjon_OmsorgspengerRefusjon() {
         List<FraværsPeriodeEntitet> fraværsPerioder = List.of(
-            new FraværsPeriodeEntitet(PeriodeEntitet.fraOgMedTilOgMed(LocalDate.now().minusDays(8), LocalDate.now().minusDays(6))),
-            new FraværsPeriodeEntitet(PeriodeEntitet.fraOgMedTilOgMed(LocalDate.now().minusDays(4), LocalDate.now().minusDays(2))));
+            new FraværsPeriodeEntitet(PeriodeEntitet.fraOgMedTilOgMed(LocalDate.of(2025, 3, 25), LocalDate.of(2025, 3, 27))),
+            new FraværsPeriodeEntitet(PeriodeEntitet.fraOgMedTilOgMed(LocalDate.of(2025, 3, 29), LocalDate.of(2025, 3, 31))));
         List<DelvisFraværsPeriodeEntitet> delvisFravær = List.of(
-            new DelvisFraværsPeriodeEntitet(LocalDate.now().minusDays(10), BigDecimal.valueOf(2)),
-            new DelvisFraværsPeriodeEntitet(LocalDate.now().minusDays(1), BigDecimal.valueOf(4)));
+            new DelvisFraværsPeriodeEntitet(LocalDate.of(2025, 3, 23), BigDecimal.valueOf(2)),
+            new DelvisFraværsPeriodeEntitet(LocalDate.of(2025, 4, 2), BigDecimal.valueOf(4)));
         String statusTekst = ForespørselTekster.lagTilleggsInformasjonForOmsorgspengerRefusjon(fraværsPerioder, delvisFravær);
-        var forventetTekst = String.format("For %s, %s, %s, %s, %s, %s, %s, %s.",
-            delvisFravær.getFirst().getDato().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
-            fraværsPerioder.getFirst().getPeriode().getFom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
-            fraværsPerioder.getFirst().getPeriode().getFom().plusDays(1).format(DateTimeFormatter.ofPattern("dd.MM.yy")),
-            fraværsPerioder.getFirst().getPeriode().getTom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
-            fraværsPerioder.getLast().getPeriode().getFom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
-            fraværsPerioder.getLast().getPeriode().getFom().plusDays(1).format(DateTimeFormatter.ofPattern("dd.MM.yy")),
-            fraværsPerioder.getLast().getPeriode().getTom().format(DateTimeFormatter.ofPattern("dd.MM.yy")),
-            delvisFravær.getLast().getDato().format(DateTimeFormatter.ofPattern("dd.MM.yy")));
+        var forventetTekst = "For 7 dager i mars, 1 dag i april.";
         assertEquals(forventetTekst, statusTekst);
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ref Jira: https://jira.adeo.no/browse/POFIM-216

Ble uoversiktlig med enkeldager da de i teorien kan være mange.

### **Løsning**
Viser tilleggsinfo heller som antall dager per måned, som "For 7 dager i mars, 1 dag i april."