### PR TITLE
TSFF-1423: Vis trukket periode på pdfen

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfDataMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfDataMapper.java
@@ -4,7 +4,6 @@ import static no.nav.familie.inntektsmelding.integrasjoner.dokgen.Inntektsmeldin
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -12,7 +11,6 @@ import java.util.List;
 import no.nav.familie.inntektsmelding.imdialog.modell.BortaltNaturalytelseEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.EndringsårsakEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
-import no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.RefusjonsendringEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
@@ -56,21 +54,6 @@ public class InntektsmeldingPdfDataMapper {
         }
 
         return imDokumentdataBuilder.build();
-    }
-
-    private static Omsorgspenger mapOmsorgspenger(OmsorgspengerEntitet omsorgspenger) {
-        var datoFormat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
-        var fraværsPerioder = omsorgspenger.getFraværsPerioder()
-            .stream()
-            .map(fp -> new Omsorgspenger.FraværsPeriode(fp.getPeriode().getFom().format(datoFormat), fp.getPeriode().getTom().format(datoFormat)))
-            .toList();
-
-        var delvisFraværsPerioder = omsorgspenger.getDelvisFraværsPerioder()
-            .stream()
-            .map(dfp -> new Omsorgspenger.DelvisFraværsPeriode(dfp.getDato().format(datoFormat), dfp.getTimer()))
-            .toList();
-
-        return new Omsorgspenger(omsorgspenger.isHarUtbetaltPliktigeDager(), fraværsPerioder, delvisFraværsPerioder);
     }
 
     private static List<Endringsarsak> mapEndringsårsaker(List<EndringsårsakEntitet> endringsårsaker) {

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenTjeneste.java
@@ -50,7 +50,7 @@ public class K9DokgenTjeneste {
         }
 
         var imDokumentdata = InntektsmeldingPdfDataMapper.mapInntektsmeldingData(inntektsmelding, arbeidsgiverNavn, personInfo, arbeidsgvierIdent);
-        return genererPdf(imDokumentdata, inntektsmeldingsid);
+        return genererPdfForInntektsmelding(imDokumentdata, inntektsmeldingsid);
     }
 
     private byte[] genererPdfForOmsorgspengerRefusjon(OmsorgspengerRefusjonPdfData imDokumentData, int inntektsmeldingId) {
@@ -66,7 +66,7 @@ public class K9DokgenTjeneste {
         }
     }
 
-    private byte[] genererPdf(InntektsmeldingPdfData imDokumentData, int inntektsmeldingId) {
+    private byte[] genererPdfForInntektsmelding(InntektsmeldingPdfData imDokumentData, int inntektsmeldingId) {
         try {
             byte[] pdf = k9DokgenKlient.genererPdf(imDokumentData);
             LOG.info("Pdf av inntektsmelding med id {} ble generert.", inntektsmeldingId);

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/Omsorgspenger.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/Omsorgspenger.java
@@ -10,7 +10,8 @@ import jakarta.validation.constraints.NotNull;
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record Omsorgspenger(@NotNull Boolean harUtbetaltPliktigeDager,
                             List<FraværsPeriode> fraværsPerioder,
-                            List<DelvisFraværsPeriode> delvisFraværsPerioder) {
+                            List<DelvisFraværsPeriode> delvisFraværsPerioder,
+                            List<TrukketFraværsPeriode> trukketFraværsPerioder) {
 
     @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public record FraværsPeriode(@NotNull String fom,
@@ -21,5 +22,9 @@ public record Omsorgspenger(@NotNull Boolean harUtbetaltPliktigeDager,
     @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public record DelvisFraværsPeriode(@NotNull String dato,
                                        @NotNull BigDecimal timer) {
+    }
+
+    @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    public record TrukketFraværsPeriode(@NotNull String dato) {
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfDataMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfDataMapper.java
@@ -47,10 +47,17 @@ public class OmsorgspengerRefusjonPdfDataMapper {
 
         var delvisFraværsPerioder = omsorgspenger.getDelvisFraværsPerioder()
             .stream()
+            .filter(dfp -> dfp.getTimer().compareTo(BigDecimal.ZERO) > 0)
             .map(dfp -> new Omsorgspenger.DelvisFraværsPeriode(dfp.getDato().format(datoFormat), dfp.getTimer()))
             .toList();
 
-        return new Omsorgspenger(omsorgspenger.isHarUtbetaltPliktigeDager(), fraværsPerioder, delvisFraværsPerioder);
+        var trukketFraværsPerioder = omsorgspenger.getDelvisFraværsPerioder()
+            .stream()
+            .filter(dfp -> dfp.getTimer().compareTo(BigDecimal.ZERO) == 0)
+            .map(dfp -> new Omsorgspenger.TrukketFraværsPeriode(dfp.getDato().format(datoFormat)))
+            .toList();
+
+        return new Omsorgspenger(omsorgspenger.isHarUtbetaltPliktigeDager(), fraværsPerioder, delvisFraværsPerioder, trukketFraværsPerioder);
     }
 
     private static List<Endringsarsak> mapEndringsårsaker(List<EndringsårsakEntitet> endringsårsaker) {


### PR DESCRIPTION
### **Behov / Bakgrunn**
I oppsummeringen viser vi trukket periode under en egen overskrift og ikke bare som en delvis periode med 0 timer. 

Jira: https://jira.adeo.no/browse/TSFF-1423

### **Løsning**
Trekk ut trukket periode som eget datafelt til pdf-en

Relatert PR: https://github.com/navikt/k9-dokgen/pull/286

### **Andre endringer**
- Fjerner ubrukt metode `mapOmsorgspenger()`
- Rename genererPdf -> genererPdfForInntektsmelding

