### PR TITLE
TSFF-1364: Legg til ny StatistikkMetrikkTask for monitorering av taskfeil

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/metrikker/StatistikkMetrikkTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/metrikker/StatistikkMetrikkTask.java
@@ -4,11 +4,12 @@ import static no.nav.vedtak.log.metrics.MetricsUtil.REGISTRY;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 import no.nav.familie.inntektsmelding.prosesstask.ProsessTaskRepository;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -33,12 +34,7 @@ public class StatistikkMetrikkTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        long startTime = System.nanoTime();
-
         var feilendeProsessTasker = prosessTaskRepository.tellAntallFeilendeProsessTasker();
         REGISTRY.gauge(PROSESS_TASK_METRIKK_NAVN, new AtomicLong(feilendeProsessTasker));
-
-        var varighet = System.nanoTime() - startTime;
-        LOG.info("Henting av statistikk tok: {}", varighet);
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/metrikker/StatistikkMetrikkTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/metrikker/StatistikkMetrikkTask.java
@@ -1,0 +1,44 @@
+package no.nav.familie.inntektsmelding.metrikker;
+
+import static no.nav.vedtak.log.metrics.MetricsUtil.REGISTRY;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.familie.inntektsmelding.prosesstask.ProsessTaskRepository;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+@ApplicationScoped
+@ProsessTask(value = "statistikk.metrikker", cronExpression = "0 */5 * * * *", maxFailedRuns = 20, firstDelay = 60)
+public class StatistikkMetrikkTask implements ProsessTaskHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StatistikkMetrikkTask.class);
+    private static final String PROSESS_TASK_METRIKK_NAVN = "k9-inntektsmelding.prosessTask.feilende";
+    private ProsessTaskRepository prosessTaskRepository;
+
+    public StatistikkMetrikkTask() {
+        // CDI
+    }
+
+    @Inject
+    public StatistikkMetrikkTask(ProsessTaskRepository prosessTaskRepository) {
+        this.prosessTaskRepository = prosessTaskRepository;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        long startTime = System.nanoTime();
+
+        var feilendeProsessTasker = prosessTaskRepository.tellAntallFeilendeProsessTasker();
+        REGISTRY.gauge(PROSESS_TASK_METRIKK_NAVN, new AtomicLong(feilendeProsessTasker));
+
+        var varighet = System.nanoTime() - startTime;
+        LOG.info("Henting av statistikk tok: {}", varighet);
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/prosesstask/ProsessTaskRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/prosesstask/ProsessTaskRepository.java
@@ -1,0 +1,33 @@
+package no.nav.familie.inntektsmelding.prosesstask;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+
+@ApplicationScoped
+public class ProsessTaskRepository {
+    private EntityManager entityManager;
+
+    @Inject
+    public ProsessTaskRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public long tellAntallFeilendeProsessTasker() {
+        return entityManager.createQuery("""
+                SELECT COUNT(p)
+                FROM ProsessTaskEntitet p
+                WHERE (
+                    p.status = 'FEILET'
+                    OR ((p.status IN ('KLAR', 'VETO')) AND p.opprettetTid < :tidspunkt_i_dag_tidlig AND (p.nesteKjøringEtter IS NULL OR p.nesteKjøringEtter < :tidspunkt_nå))
+                    OR (p.status IN ('VENTER_SVAR', 'SUSPENDERT') AND p.opprettetTid < :tidspunkt_i_dag_tidlig)
+                )
+                """, Long.class)
+            .setParameter("tidspunkt_i_dag_tidlig", LocalDateTime.now().truncatedTo(ChronoUnit.DAYS))
+            .setParameter("tidspunkt_nå", LocalDateTime.now())
+            .getSingleResult();
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/prosesstask/ProsessTaskRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/prosesstask/ProsessTaskRepository.java
@@ -11,6 +11,10 @@ import jakarta.persistence.EntityManager;
 public class ProsessTaskRepository {
     private EntityManager entityManager;
 
+    public ProsessTaskRepository() {
+        // CDI
+    }
+
     @Inject
     public ProsessTaskRepository(EntityManager entityManager) {
         this.entityManager = entityManager;


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi har behov for en oversikt over taskfeil for å sørge for trygg drift av k9-inntektsmelding.

Jira: https://jira.adeo.no/browse/TSFF-1364

### **Løsning**
Oppretter en statistikk-task som slår opp feilende tasker i databasen og oppdaterer en gauge metrikk i prometheus.
