### PR TITLE
TSFF-1378: Slå på tracing og logging til grafana

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -30,6 +30,17 @@ spec:
   prometheus:
     enabled: true
     path: /k9/inntektsmelding/internal/metrics/prometheus
+  observability:
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
   replicas:
     min: {{minReplicas}}
     max: {{maxReplicas}}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker å slå på tracing og logging til både Loki (Grafana) og Elastic.

### **Løsning**
Slår på tracing og logging
