### PR TITLE
TSFF-1378: Slå på tracing og logging til grafana 2

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -40,7 +40,6 @@ spec:
       runtime: java
       destinations:
         - id: "grafana-lgtm"
-        - id: "elastic-apm"
   replicas:
     min: {{minReplicas}}
     max: {{maxReplicas}}


### PR DESCRIPTION
### **Behov / Bakgrunn**
I forbindelse med https://github.com/navikt/k9-inntektsmelding/pull/447 la vi inn tracing til elastic. Det er ikke tilgjengelig i gcp. 

### **Løsning**
Fjerner "elastic-apm"