### PR TITLE
Revert "Fiks: Legg til stack trace for json mapping error"

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/server/exceptions/JsonMappingExceptionMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/server/exceptions/JsonMappingExceptionMapper.java
@@ -16,15 +16,7 @@ public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingEx
     @Override
     public Response toResponse(JsonMappingException exception) {
         var feil = "FIM-252294: JSON-mapping feil";
-        LOG.warn(feil, new FeltFeilDto("stack_trace", getStackTraceAsString(exception)));
+        LOG.warn(feil);
         return Response.status(Response.Status.BAD_REQUEST).entity(new FeilDto(feil)).type(MediaType.APPLICATION_JSON).build();
-    }
-
-    private String getStackTraceAsString(JsonMappingException exception) {
-        StringBuilder sb = new StringBuilder();
-        for (StackTraceElement element : exception.getStackTrace()) {
-            sb.append(element.toString()).append("\n");
-        }
-        return sb.toString();
     }
 }


### PR DESCRIPTION
Reverts navikt/k9-inntektsmelding#450

### Bakgrunn
Vi ønsket å legge til mer logging for å finne ut av hva som gikk galt. Nå viser det seg at vi har funnet feilen og har ikke samme behov lenger. Siden stack trace av en json parsing feil _kan_ inneholde sensitiv info, ønsker vi å reverte denne.

