### PR TITLE
Filtrerer vekk duplikate utgåtte forespørsler fra hent-forepørsler

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
@@ -2,6 +2,7 @@ package no.nav.familie.inntektsmelding.forespørsel.rest;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -139,9 +140,32 @@ public class ForespørselRest {
         sjekkErSystemkall();
 
         var forespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(new SaksnummerDto(saksnummer), null, null);
+        forespørsler = filtrerDuplikateForespørsler(forespørsler);
         var forespørselDtos = forespørsler.stream().map(ForespørselRest::mapTilDto).toList();
 
         return Response.ok(forespørselDtos).build();
+    }
+
+    private List<ForespørselEntitet> filtrerDuplikateForespørsler(List<ForespørselEntitet> forespørsler) {
+        List<ForespørselEntitet> resultat = new ArrayList<>();
+        for (ForespørselEntitet forespørsel : forespørsler) {
+            if (forespørsel.getStatus() == ForespørselStatus.UTGÅTT) {
+                var duplikater = forespørsler.stream().filter(f -> f.getSkjæringstidspunkt().equals(forespørsel.getSkjæringstidspunkt())
+                    && f.getOrganisasjonsnummer().equals(forespørsel.getOrganisasjonsnummer())
+                    && f != forespørsel).toList();
+
+                boolean harDuplikatFerdigEllerUnderBehandling = duplikater.stream()
+                    .anyMatch(d -> d.getStatus() == ForespørselStatus.FERDIG || d.getStatus() == ForespørselStatus.UNDER_BEHANDLING);
+                boolean harDuplikatNyereUtgått = duplikater.stream()
+                    .anyMatch(d -> d.getStatus() == ForespørselStatus.UTGÅTT && d.getOpprettetTidspunkt().isAfter(forespørsel.getOpprettetTidspunkt()));
+                if (!harDuplikatFerdigEllerUnderBehandling && !harDuplikatNyereUtgått) {
+                    resultat.add(forespørsel);
+                }
+            } else {
+                resultat.add(forespørsel);
+            }
+        }
+        return resultat;
     }
 
     record ForespørselDto(UUID uuid, OrganisasjonsnummerDto organisasjonsnummer, LocalDate skjæringstidspunkt, AktørIdDto brukerAktørId,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi kan ha flere forespørsler med samme stp og orgnr hvis en eller flere er utgått. Da trenger vi ikke sende alle disse i responsen, det blir bare forvirrende for k9-sak.
### **Løsning**
Fjerner utgåtte forespørsler fra responsen dersom det finnes duplikate som har en annen status eller er nyere.