### PR TITLE
TSFF-1733: Legg til riktig merkelapp og sakstittel ved opprettelse av forespørsel for vanlig inntektsmelding for omsorgspenger

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -273,7 +273,7 @@ public class ForespørselBehandlingTjeneste {
             saksnummer,
             førsteUttaksdato,
             etterspurtePerioder);
-        var person = personTjeneste.hentPersonInfoFraAktørId(aktørId, ytelsetype);
+        var person = personTjeneste.hentPersonInfoFraAktørId(aktørId);
         var merkelapp = ForespørselTekster.finnMerkelapp(ytelsetype);
         var skjemaUri = URI.create(inntektsmeldingSkjemaLenke + "/" + uuid);
         var arbeidsgiverNotifikasjonSakId = arbeidsgiverNotifikasjon.opprettSak(uuid.toString(),
@@ -318,7 +318,7 @@ public class ForespørselBehandlingTjeneste {
             organisasjonsnummer,
             skjæringstidspunkt);
 
-        var person = personTjeneste.hentPersonInfoFraAktørId(aktørId, Ytelsetype.OMSORGSPENGER);
+        var person = personTjeneste.hentPersonInfoFraAktørId(aktørId);
         var merkelapp = Merkelapp.REFUSJONSKRAV_OMS;
         var skjemaUri = URI.create(inntektsmeldingSkjemaLenke + "/refusjon-omsorgspenger/" + organisasjonsnummer.orgnr() + "/" + uuid);
         var fagerSakId = arbeidsgiverNotifikasjon.opprettSak(uuid.toString(),

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -23,6 +23,7 @@ import no.nav.familie.inntektsmelding.forvaltning.rest.InntektsmeldingForespørs
 import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjon;
+import no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.Merkelapp;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
@@ -278,7 +279,7 @@ public class ForespørselBehandlingTjeneste {
         var arbeidsgiverNotifikasjonSakId = arbeidsgiverNotifikasjon.opprettSak(uuid.toString(),
             merkelapp,
             organisasjonsnummer.orgnr(),
-            ForespørselTekster.lagSaksTittel(person.mapFulltNavn(), person.fødselsdato(), ytelsetype),
+            ForespørselTekster.lagSaksTittelInntektsmelding(person.mapFulltNavn(), person.fødselsdato()),
             skjemaUri);
 
         arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(arbeidsgiverNotifikasjonSakId, ForespørselTekster.lagTilleggsInformasjonOrdinær(skjæringstidspunkt));
@@ -318,12 +319,12 @@ public class ForespørselBehandlingTjeneste {
             skjæringstidspunkt);
 
         var person = personTjeneste.hentPersonInfoFraAktørId(aktørId, Ytelsetype.OMSORGSPENGER);
-        var merkelapp = ForespørselTekster.finnMerkelapp(Ytelsetype.OMSORGSPENGER);
+        var merkelapp = Merkelapp.REFUSJONSKRAV_OMS;
         var skjemaUri = URI.create(inntektsmeldingSkjemaLenke + "/refusjon-omsorgspenger/" + organisasjonsnummer.orgnr() + "/" + uuid);
         var fagerSakId = arbeidsgiverNotifikasjon.opprettSak(uuid.toString(),
             merkelapp,
             organisasjonsnummer.orgnr(),
-            ForespørselTekster.lagSaksTittel(person.mapFulltNavn(), person.fødselsdato(), Ytelsetype.OMSORGSPENGER),
+            ForespørselTekster.lagSaksTittelRefusjon(person.mapFulltNavn(), person.fødselsdato()),
             skjemaUri);
 
         forespørselTjeneste.setArbeidsgiverNotifikasjonSakId(uuid, fagerSakId);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -319,12 +319,12 @@ public class ForespørselBehandlingTjeneste {
             skjæringstidspunkt);
 
         var person = personTjeneste.hentPersonInfoFraAktørId(aktørId);
-        var merkelapp = Merkelapp.REFUSJONSKRAV_OMS;
+        var merkelapp = Merkelapp.REFUSJONSKRAV_OMP;
         var skjemaUri = URI.create(inntektsmeldingSkjemaLenke + "/refusjon-omsorgspenger/" + organisasjonsnummer.orgnr() + "/" + uuid);
         var fagerSakId = arbeidsgiverNotifikasjon.opprettSak(uuid.toString(),
             merkelapp,
             organisasjonsnummer.orgnr(),
-            ForespørselTekster.lagSaksTittelRefusjon(person.mapFulltNavn(), person.fødselsdato()),
+            ForespørselTekster.lagSaksTittelRefusjonskrav(person.mapFulltNavn(), person.fødselsdato()),
             skjemaUri);
 
         forespørselTjeneste.setArbeidsgiverNotifikasjonSakId(uuid, fagerSakId);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
@@ -106,7 +106,7 @@ class ForespørselTekster {
         return String.format("Inntektsmelding for %s (%s)", capitalizeFully(navn), fødselsdato.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
     }
 
-    public static String lagSaksTittelRefusjon(String navn, LocalDate fødselsdato) {
+    public static String lagSaksTittelRefusjonskrav(String navn, LocalDate fødselsdato) {
         return String.format("Refusjonskrav for %s (%s)", capitalizeFully(navn), fødselsdato.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
     }
 
@@ -125,7 +125,7 @@ class ForespørselTekster {
     public static Merkelapp finnMerkelapp(Ytelsetype ytelsetype) {
         return switch (ytelsetype) {
             case PLEIEPENGER_SYKT_BARN -> Merkelapp.INNTEKTSMELDING_PSB;
-            case OMSORGSPENGER -> Merkelapp.REFUSJONSKRAV_OMS;
+            case OMSORGSPENGER -> Merkelapp.INNTEKTSMELDING_OMP;
             case PLEIEPENGER_NÆRSTÅENDE -> Merkelapp.INNTEKTSMELDING_PILS;
             case OPPLÆRINGSPENGER -> Merkelapp.INNTEKTSMELDING_OPP;
         };

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
@@ -102,11 +102,12 @@ class ForespørselTekster {
         return String.format(OPPGAVE_TEKST_NY, mapYtelsestypeNavn(ytelseType));
     }
 
-    public static String lagSaksTittel(String navn, LocalDate fødselsdato, Ytelsetype ytelsetype) {
-        return switch (ytelsetype) {
-            case PLEIEPENGER_SYKT_BARN, PLEIEPENGER_NÆRSTÅENDE, OPPLÆRINGSPENGER -> String.format("Inntektsmelding for %s (%s)", capitalizeFully(navn), fødselsdato.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
-            case OMSORGSPENGER -> String.format("Refusjonskrav for %s (%s)", capitalizeFully(navn), fødselsdato.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
-        };
+    public static String lagSaksTittelInntektsmelding(String navn, LocalDate fødselsdato) {
+        return String.format("Inntektsmelding for %s (%s)", capitalizeFully(navn), fødselsdato.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
+    }
+
+    public static String lagSaksTittelRefusjon(String navn, LocalDate fødselsdato) {
+        return String.format("Refusjonskrav for %s (%s)", capitalizeFully(navn), fødselsdato.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
     }
 
     public static String lagVarselTekst(Ytelsetype ytelsetype, Organisasjon org) {
@@ -124,7 +125,7 @@ class ForespørselTekster {
     public static Merkelapp finnMerkelapp(Ytelsetype ytelsetype) {
         return switch (ytelsetype) {
             case PLEIEPENGER_SYKT_BARN -> Merkelapp.INNTEKTSMELDING_PSB;
-            case OMSORGSPENGER -> Merkelapp.INNTEKTSMELDING_OMP;
+            case OMSORGSPENGER -> Merkelapp.REFUSJONSKRAV_OMS;
             case PLEIEPENGER_NÆRSTÅENDE -> Merkelapp.INNTEKTSMELDING_PILS;
             case OPPLÆRINGSPENGER -> Merkelapp.INNTEKTSMELDING_OPP;
         };

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -187,7 +187,7 @@ public class InntektsmeldingTjeneste {
                                                                      Ytelsetype ytelsetype,
                                                                      LocalDate førsteFraværsdag,
                                                                      OrganisasjonsnummerDto organisasjonsnummer) {
-        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer, ytelsetype);
+        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
 
         var eksisterendeForepørsler = forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(personInfo.aktørId(), ytelsetype, organisasjonsnummer.orgnr());
         var forespørslerSomMatcherFraværsdag = eksisterendeForepørsler.stream()
@@ -269,7 +269,7 @@ public class InntektsmeldingTjeneste {
             throw new IllegalStateException("Mangler innlogget bruker kontekst.");
         }
         var pid = KontekstHolder.getKontekst().getUid();
-        var personInfo = personTjeneste.hentPersonFraIdent(PersonIdent.fra(pid), ytelsetype);
+        var personInfo = personTjeneste.hentPersonFraIdent(PersonIdent.fra(pid));
         return new InntektsmeldingDialogDto.InnsenderDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(),
             personInfo.telefonnummer());
     }
@@ -301,7 +301,7 @@ public class InntektsmeldingTjeneste {
     }
 
     private InntektsmeldingDialogDto.PersonInfoResponseDto lagPersonDto(AktørIdEntitet aktørId, Ytelsetype ytelseType) {
-        var personInfo = personTjeneste.hentPersonInfoFraAktørId(aktørId, ytelseType);
+        var personInfo = personTjeneste.hentPersonInfoFraAktørId(aktørId);
         return new InntektsmeldingDialogDto.PersonInfoResponseDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(),
             personInfo.fødselsnummer().getIdent(), personInfo.aktørId().getAktørId());
     }
@@ -309,7 +309,7 @@ public class InntektsmeldingTjeneste {
     public Optional<SlåOppArbeidstakerResponseDto> finnArbeidsforholdForFnr(PersonIdent fødselsnummer, Ytelsetype ytelsetype,
                                                                             LocalDate førsteFraværsdag) {
         // TODO Skal vi sjekke noe mtp kode 6/7
-        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer, ytelsetype);
+        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
         if (personInfo == null) {
             return Optional.empty();
         }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
@@ -2,9 +2,10 @@ package no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon;
 
 public enum Merkelapp {
     INNTEKTSMELDING_PSB("Inntektsmelding pleiepenger sykt barn"),
-    INNTEKTSMELDING_OMP("Refusjonskrav for omsorgspenger"),
     INNTEKTSMELDING_PILS("Inntektsmelding pleiepenger i livets sluttfase"),
-    INNTEKTSMELDING_OPP("Inntektsmelding opplæringspenger");
+    INNTEKTSMELDING_OPP("Inntektsmelding opplæringspenger"),
+    INNTEKTSMELDING_OMS("Inntektsmelding omsorgspenger"),
+    REFUSJONSKRAV_OMS("Refusjonskrav for omsorgspenger");
 
     private final String beskrivelse;
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/Merkelapp.java
@@ -4,8 +4,8 @@ public enum Merkelapp {
     INNTEKTSMELDING_PSB("Inntektsmelding pleiepenger sykt barn"),
     INNTEKTSMELDING_PILS("Inntektsmelding pleiepenger i livets sluttfase"),
     INNTEKTSMELDING_OPP("Inntektsmelding opplæringspenger"),
-    INNTEKTSMELDING_OMS("Inntektsmelding omsorgspenger"),
-    REFUSJONSKRAV_OMS("Refusjonskrav for omsorgspenger");
+    INNTEKTSMELDING_OMP("Inntektsmelding omsorgspenger"),
+    REFUSJONSKRAV_OMP("Refusjonskrav for omsorgspenger");
 
     private final String beskrivelse;
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenTjeneste.java
@@ -41,7 +41,7 @@ public class K9DokgenTjeneste {
         var arbeidsgvierIdent = inntektsmelding.getArbeidsgiverIdent();
         var inntektsmeldingsid = inntektsmelding.getId() != null ? inntektsmelding.getId().intValue() : 1;
 
-        personInfo = personTjeneste.hentPersonInfoFraAktørId(inntektsmelding.getAktørId(), inntektsmelding.getYtelsetype());
+        personInfo = personTjeneste.hentPersonInfoFraAktørId(inntektsmelding.getAktørId());
         arbeidsgiverNavn = finnArbeidsgiverNavn(inntektsmelding, arbeidsgvierIdent);
 
         if (inntektsmelding.getYtelsetype() == Ytelsetype.OMSORGSPENGER) {
@@ -83,7 +83,7 @@ public class K9DokgenTjeneste {
         String arbeidsgiverNavn;
         if (!OrganisasjonsnummerValidator.erGyldig(arbeidsgvierIdent)) {
             var personIdent = new PersonIdent(arbeidsgvierIdent);
-            arbeidsgiverNavn = personTjeneste.hentPersonFraIdent(personIdent, inntektsmelding.getYtelsetype()).mapNavn();
+            arbeidsgiverNavn = personTjeneste.hentPersonFraIdent(personIdent).mapNavn();
         } else {
             arbeidsgiverNavn = organisasjonTjeneste.finnOrganisasjon(arbeidsgvierIdent).navn();
         }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjeneste.java
@@ -125,8 +125,8 @@ public class JoarkTjeneste {
     }
 
     private AvsenderMottaker lagAvsenderPrivatperson(InntektsmeldingEntitet inntektsmeldingEntitet) {
-        var personInfo = personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(inntektsmeldingEntitet.getArbeidsgiverIdent()),
-            inntektsmeldingEntitet.getYtelsetype());
+        var personInfo = personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(inntektsmeldingEntitet.getArbeidsgiverIdent())
+        );
         return new AvsenderMottaker(personInfo.fødselsnummer().getIdent(), AvsenderMottaker.AvsenderMottakerIdType.FNR, personInfo.mapNavn());
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjeneste.java
@@ -125,8 +125,7 @@ public class JoarkTjeneste {
     }
 
     private AvsenderMottaker lagAvsenderPrivatperson(InntektsmeldingEntitet inntektsmeldingEntitet) {
-        var personInfo = personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(inntektsmeldingEntitet.getArbeidsgiverIdent())
-        );
+        var personInfo = personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(inntektsmeldingEntitet.getArbeidsgiverIdent()));
         return new AvsenderMottaker(personInfo.fødselsnummer().getIdent(), AvsenderMottaker.AvsenderMottakerIdType.FNR, personInfo.mapNavn());
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjeneste.java
@@ -46,7 +46,7 @@ public class PersonTjeneste {
         this.pdlKlient = pdlKlient;
     }
 
-    public PersonInfo hentPersonInfoFraAktørId(AktørIdEntitet aktørId, Ytelsetype ytelseType) {
+    public PersonInfo hentPersonInfoFraAktørId(AktørIdEntitet aktørId) {
         var request = new HentPersonQueryRequest();
         request.setIdent(aktørId.getAktørId());
 
@@ -63,7 +63,7 @@ public class PersonTjeneste {
         return new PersonInfo(navn.getFornavn(), navn.getMellomnavn(), navn.getEtternavn(), personIdent, aktørId, mapFødselsdato(person), null);
     }
 
-    public PersonInfo hentPersonFraIdent(PersonIdent personIdent, Ytelsetype ytelseType) {
+    public PersonInfo hentPersonFraIdent(PersonIdent personIdent) {
         var request = new HentPersonQueryRequest();
         request.setIdent(personIdent.getIdent());
 
@@ -93,7 +93,7 @@ public class PersonTjeneste {
             throw new IllegalStateException("Mangler innlogget bruker kontekst.");
         }
         var pid = KontekstHolder.getKontekst().getUid();
-        return hentPersonFraIdent(PersonIdent.fra(pid), ytelsetype);
+        return hentPersonFraIdent(PersonIdent.fra(pid));
     }
 
     private LocalDate mapFødselsdato(Person person) {

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -56,7 +56,7 @@ public class RefusjonOmsorgsdagerService {
             ))
             .toList();
 
-        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer, Ytelsetype.OMSORGSPENGER);
+        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
         if (arbeidsforholdMedOrgnavn.isEmpty() || personInfo == null) {
             return null;
         }
@@ -85,7 +85,7 @@ public class RefusjonOmsorgsdagerService {
     }
 
     public HentInntektsopplysningerResponseDto hentInntektsopplysninger(PersonIdent fødselsnummer, String organisasjonsnummer, LocalDate skjæringstidspunkt) {
-        var person = personTjeneste.hentPersonFraIdent(fødselsnummer, Ytelsetype.OMSORGSPENGER);
+        var person = personTjeneste.hentPersonFraIdent(fødselsnummer);
         var arbeidsforhold = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(
             fødselsnummer,
             skjæringstidspunkt

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
@@ -85,7 +85,7 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
     void skal_opprette_opprette_arbeidsgiverinitiert_forespørsel_uten_oppgave() {
         var aktørIdent = new AktørIdEntitet(AKTØR_ID);
         mockInfoForOpprettelse(AKTØR_ID, YTELSETYPE, BRREG_ORGNUMMER, SAK_ID, OPPGAVE_ID);
-        when(personTjeneste.hentPersonInfoFraAktørId(any(), any())).thenReturn(new PersonInfo("12345678910", "test", "test", new PersonIdent("12345678910"), aktørIdent, LocalDate.now(), null));
+        when(personTjeneste.hentPersonInfoFraAktørId(any())).thenReturn(new PersonInfo("12345678910", "test", "test", new PersonIdent("12345678910"), aktørIdent, LocalDate.now(), null));
         when(arbeidsgiverNotifikasjon.opprettSak(any(), any(), any(), any(), any())).thenReturn(SAK_ID);
 
 
@@ -425,7 +425,7 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
             null);
         var sakTittel = ForespørselTekster.lagSaksTittelInntektsmelding(personInfo.mapFulltNavn(), personInfo.fødselsdato());
 
-        lenient().when(personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(aktørId), ytelsetype)).thenReturn(personInfo);
+        lenient().when(personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(aktørId))).thenReturn(personInfo);
         lenient().when(arbeidsgiverNotifikasjon.opprettSak(any(), any(), eq(brregOrgnummer), eq(sakTittel), any())).thenReturn(sakId);
         lenient().when(arbeidsgiverNotifikasjon.opprettOppgave(any(), any(), any(), eq(brregOrgnummer), any(), any(), any(), any()))
             .thenReturn(oppgaveId);

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
@@ -423,7 +423,7 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
             new AktørIdEntitet(aktørId),
             LocalDate.of(1991, 1, 1).minusYears(30),
             null);
-        var sakTittel = ForespørselTekster.lagSaksTittel(personInfo.mapFulltNavn(), personInfo.fødselsdato(), ytelsetype);
+        var sakTittel = ForespørselTekster.lagSaksTittelInntektsmelding(personInfo.mapFulltNavn(), personInfo.fødselsdato());
 
         lenient().when(personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(aktørId), ytelsetype)).thenReturn(personInfo);
         lenient().when(arbeidsgiverNotifikasjon.opprettSak(any(), any(), eq(brregOrgnummer), eq(sakTittel), any())).thenReturn(sakId);

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
@@ -29,7 +29,7 @@ class ForespørselTeksterTest {
 
     @Test
     void lagSaksTittelOmsorgspengerRefusjon() {
-        String saksTittel = ForespørselTekster.lagSaksTittelRefusjon("OLA NORDMANN", LocalDate.of(2021, 02, 1));
+        String saksTittel = ForespørselTekster.lagSaksTittelRefusjonskrav("OLA NORDMANN", LocalDate.of(2021, 02, 1));
         assertEquals("Refusjonskrav for Ola Nordmann (01.02.21)", saksTittel);
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
@@ -22,14 +22,14 @@ import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 class ForespørselTeksterTest {
 
     @Test
-    void lagSaksTittel() {
-        String saksTittel = ForespørselTekster.lagSaksTittel("OLA NORDMANN", LocalDate.of(2021, 02, 1), Ytelsetype.PLEIEPENGER_SYKT_BARN);
+    void lagSaksTittelInntektsmelding() {
+        String saksTittel = ForespørselTekster.lagSaksTittelInntektsmelding("OLA NORDMANN", LocalDate.of(2021, 02, 1));
         assertEquals("Inntektsmelding for Ola Nordmann (01.02.21)", saksTittel);
     }
 
     @Test
     void lagSaksTittelOmsorgspengerRefusjon() {
-        String saksTittel = ForespørselTekster.lagSaksTittel("OLA NORDMANN", LocalDate.of(2021, 02, 1), Ytelsetype.OMSORGSPENGER);
+        String saksTittel = ForespørselTekster.lagSaksTittelRefusjon("OLA NORDMANN", LocalDate.of(2021, 02, 1));
         assertEquals("Refusjonskrav for Ola Nordmann (01.02.21)", saksTittel);
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
@@ -106,12 +106,12 @@ class InntektsmeldingTjenesteTest {
         when(forespørselBehandlingTjeneste.hentForespørsel(uuid)).thenReturn(Optional.of(forespørsel));
         when(organisasjonTjeneste.finnOrganisasjon(forespørsel.getOrganisasjonsnummer())).thenReturn(
             new Organisasjon("Bedriften", forespørsel.getOrganisasjonsnummer()));
-        when(personTjeneste.hentPersonInfoFraAktørId(forespørsel.getAktørId(), forespørsel.getYtelseType())).thenReturn(
+        when(personTjeneste.hentPersonInfoFraAktørId(forespørsel.getAktørId())).thenReturn(
             new PersonInfo("Navn", null, "Navnesen", new PersonIdent("12121212122"), forespørsel.getAktørId(), LocalDate.now(), null));
         var innsenderNavn = "Ine";
         var innsenderEtternavn = "Sender";
         var innsenderTelefonnummer = "+4711111111";
-        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID), forespørsel.getYtelseType())).thenReturn(
+        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID))).thenReturn(
             new PersonInfo(innsenderNavn, null, innsenderEtternavn, new PersonIdent(INNMELDER_UID), null, LocalDate.now(), innsenderTelefonnummer));
         var inntekt1 = new Inntektsopplysninger.InntektMåned(BigDecimal.valueOf(52000), YearMonth.of(2024, 3), MånedslønnStatus.BRUKT_I_GJENNOMSNITT);
         var inntekt2 = new Inntektsopplysninger.InntektMåned(BigDecimal.valueOf(52000), YearMonth.of(2024, 4), MånedslønnStatus.BRUKT_I_GJENNOMSNITT);
@@ -175,12 +175,12 @@ class InntektsmeldingTjenesteTest {
         when(forespørselBehandlingTjeneste.hentForespørsel(uuid)).thenReturn(Optional.of(forespørsel));
         when(organisasjonTjeneste.finnOrganisasjon(forespørsel.getOrganisasjonsnummer())).thenReturn(
             new Organisasjon("Bedriften", forespørsel.getOrganisasjonsnummer()));
-        when(personTjeneste.hentPersonInfoFraAktørId(forespørsel.getAktørId(), forespørsel.getYtelseType())).thenReturn(
+        when(personTjeneste.hentPersonInfoFraAktørId(forespørsel.getAktørId())).thenReturn(
             new PersonInfo("Navn", null, "Navnesen", new PersonIdent("12121212122"), forespørsel.getAktørId(), LocalDate.now(), null));
         var innsenderNavn = "Ine";
         var innsenderEtternavn = "Sender";
         var innsenderTelefonnummer = "+4711111111";
-        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID), forespørsel.getYtelseType())).thenReturn(
+        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID))).thenReturn(
             new PersonInfo(innsenderNavn, null, innsenderEtternavn, new PersonIdent(INNMELDER_UID), null, LocalDate.now(), innsenderTelefonnummer));
         when(inntektTjeneste.hentInntekt(forespørsel.getAktørId(), forespørsel.getSkjæringstidspunkt(), LocalDate.now(),
             forespørsel.getOrganisasjonsnummer())).thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000),
@@ -247,7 +247,7 @@ class InntektsmeldingTjenesteTest {
         var fnr = new PersonIdent("11111111111");
         var førsteFraværsdag = LocalDate.now();
         var aktørId = new AktørIdEntitet("9999999999999");
-        when(personTjeneste.hentPersonFraIdent(fnr, Ytelsetype.PLEIEPENGER_SYKT_BARN)).thenReturn(
+        when(personTjeneste.hentPersonFraIdent(fnr)).thenReturn(
             new PersonInfo("Navn", null, "Navnesen", new PersonIdent("12121212122"), aktørId, LocalDate.now(), null));
         var orgnr = "999999999";
         when(arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fnr, førsteFraværsdag)).thenReturn(List.of(new ArbeidsforholdDto(orgnr,
@@ -281,8 +281,8 @@ class InntektsmeldingTjenesteTest {
             førsteFraværsdag.plusWeeks(1),
             null);
         var personInfo = new PersonInfo("Navn", null, "Navnesen", fødselsnummer, aktørId, LocalDate.now(), null);
-        when(personTjeneste.hentPersonFraIdent(fødselsnummer, ytelsetype)).thenReturn(personInfo);
-        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID), ytelsetype)).thenReturn(
+        when(personTjeneste.hentPersonFraIdent(fødselsnummer)).thenReturn(personInfo);
+        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID))).thenReturn(
             new PersonInfo("Ine", null, "Sender", new PersonIdent(INNMELDER_UID), null, LocalDate.now(), "+4711111111"));
         when(forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of(forespørsel));
         when(organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer.orgnr())).thenReturn(new Organisasjon("Bedriften",
@@ -318,9 +318,9 @@ class InntektsmeldingTjenesteTest {
         var aktørId = new AktørIdEntitet("9999999999999");
         var forespørsel = ForespørselMapper.mapForespørsel("999999999", førsteFraværsdag, aktørId.getAktørId(), ytelsetype, "123", førsteFraværsdag, null);
         var personInfo = new PersonInfo("Navn", null, "Navnesen", fødselsnummer, aktørId, LocalDate.now(), null);
-        when(personTjeneste.hentPersonFraIdent(fødselsnummer, ytelsetype)).thenReturn(personInfo);
-        when(personTjeneste.hentPersonInfoFraAktørId(aktørId, ytelsetype)).thenReturn(personInfo);
-        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID), ytelsetype)).thenReturn(
+        when(personTjeneste.hentPersonFraIdent(fødselsnummer)).thenReturn(personInfo);
+        when(personTjeneste.hentPersonInfoFraAktørId(aktørId)).thenReturn(personInfo);
+        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID))).thenReturn(
             new PersonInfo("Ine", null, "Sender", new PersonIdent(INNMELDER_UID), null, LocalDate.now(), "+4711111111"));
         when(forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of(forespørsel));
         when(forespørselBehandlingTjeneste.hentForespørsel(forespørsel.getUuid())).thenReturn(Optional.of(forespørsel));

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
@@ -9,8 +9,8 @@ class MerkelappTest {
 
     @Test
     void getBeskrivelse() {
-        assertThat(Merkelapp.REFUSJONSKRAV_OMS.getBeskrivelse()).isEqualTo("Refusjonskrav for omsorgspenger");
-        assertThat(Merkelapp.INNTEKTSMELDING_OMS.getBeskrivelse()).isEqualTo("Inntektsmelding omsorgspenger");
+        assertThat(Merkelapp.REFUSJONSKRAV_OMP.getBeskrivelse()).isEqualTo("Refusjonskrav for omsorgspenger");
+        assertThat(Merkelapp.INNTEKTSMELDING_OMP.getBeskrivelse()).isEqualTo("Inntektsmelding omsorgspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_OPP.getBeskrivelse()).isEqualTo("Inntektsmelding opplæringspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_PILS.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger i livets sluttfase");
         assertThat(Merkelapp.INNTEKTSMELDING_PSB.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger sykt barn");

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
@@ -18,7 +18,7 @@ class MerkelappTest {
 
     @Test
     void values() {
-        assertThat(Merkelapp.values()).hasSize(4);
+        assertThat(Merkelapp.values()).hasSize(5);
     }
 
     @Test

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MerkelappTest.java
@@ -9,7 +9,8 @@ class MerkelappTest {
 
     @Test
     void getBeskrivelse() {
-        assertThat(Merkelapp.INNTEKTSMELDING_OMP.getBeskrivelse()).isEqualTo("Refusjonskrav for omsorgspenger");
+        assertThat(Merkelapp.REFUSJONSKRAV_OMS.getBeskrivelse()).isEqualTo("Refusjonskrav for omsorgspenger");
+        assertThat(Merkelapp.INNTEKTSMELDING_OMS.getBeskrivelse()).isEqualTo("Inntektsmelding omsorgspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_OPP.getBeskrivelse()).isEqualTo("Inntektsmelding opplæringspenger");
         assertThat(Merkelapp.INNTEKTSMELDING_PILS.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger i livets sluttfase");
         assertThat(Merkelapp.INNTEKTSMELDING_PSB.getBeskrivelse()).isEqualTo("Inntektsmelding pleiepenger sykt barn");

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjenesteTest.java
@@ -129,7 +129,7 @@ class JoarkTjenesteTest {
             .build();
 
         // Kan foreløpig ikke teste med spesifikk request i mock siden eksternreferanse genereres on the fly
-        when(personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(aktørIdArbeidsgiver), Ytelsetype.PLEIEPENGER_SYKT_BARN)).thenReturn(
+        when(personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(aktørIdArbeidsgiver))).thenReturn(
             new PersonInfo("Navn", null, "Navnesen", new PersonIdent("9999999999999"), aktørIdSøker, LocalDate.now(), null));
         when(klient.opprettJournalpost(any(), anyBoolean())).thenReturn(new OpprettJournalpostResponse("9999", false, Collections.emptyList()));
         // Act

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
@@ -23,7 +23,6 @@ import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTje
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
-import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.ArbeidsforholdDto;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsopplysningerResponseDto;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.InnloggetBrukerDto;
@@ -71,7 +70,7 @@ class RefusjonOmsorgsdagerServiceTest {
             new SlåOppArbeidstakerResponseDto.Personinformasjon("fornavn", "mellomnavn", "etternavn", "12345678910", aktørId.getAktørId()),
             List.of(new SlåOppArbeidstakerResponseDto.ArbeidsforholdDto(orgnummer, "Arbeidsgiver AS")));
 
-        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer, Ytelsetype.OMSORGSPENGER)).thenReturn(new PersonInfo("fornavn", "mellomnavn", "etternavn", fødselsnummer, aktørId, LocalDate.now(), null));
+        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(new PersonInfo("fornavn", "mellomnavn", "etternavn", fødselsnummer, aktørId, LocalDate.now(), null));
         when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, førsteFraværsdag)).thenReturn(arbeidsforhold);
         when(organisasjonTjenesteMock.finnOrganisasjon(orgnummer)).thenReturn(new Organisasjon( "Arbeidsgiver AS", orgnummer));
 
@@ -86,7 +85,7 @@ class RefusjonOmsorgsdagerServiceTest {
         var fødselsnummer = PersonIdent.fra("12345678910");
         var førsteFraværsdag = LocalDate.now();
 
-        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer, Ytelsetype.OMSORGSPENGER)).thenReturn(null);
+        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(null);
 
         var response = service.hentArbeidstaker(fødselsnummer);
 
@@ -109,7 +108,7 @@ class RefusjonOmsorgsdagerServiceTest {
         var fødselsnummer = PersonIdent.fra("12345678910");
         var organisasjonsnummer = "999999999";
 
-        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer, Ytelsetype.OMSORGSPENGER)).thenReturn(new PersonInfo("fornavn",
+        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(new PersonInfo("fornavn",
             "mellomnavn",
             "etternavn",
             fødselsnummer,
@@ -132,7 +131,7 @@ class RefusjonOmsorgsdagerServiceTest {
         var fødselsnummer = PersonIdent.fra("12345678910");
         var organisasjonsnummer = "999999999";
 
-        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer, Ytelsetype.OMSORGSPENGER)).thenReturn(new PersonInfo("fornavn",
+        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(new PersonInfo("fornavn",
             "mellomnavn",
             "etternavn",
             fødselsnummer,
@@ -152,7 +151,7 @@ class RefusjonOmsorgsdagerServiceTest {
         var fødselsnummer = PersonIdent.fra("12345678910");
         var organisasjonsnummer = "999999999";
 
-        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer, Ytelsetype.OMSORGSPENGER)).thenReturn(null);
+        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(null);
         when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer,
             LocalDate.now())).thenReturn(List.of(new ArbeidsforholdDto(organisasjonsnummer, "ARB-1")));
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Når vi oppretter forespørsel for vanlig inntektsmelding for omsorgspenger, ønsker vi å bruke en egen merkelapp og sakstittel.

Jira: https://jira.adeo.no/browse/TSFF-1733

### **Løsning**
- Legger til egen ny merkelapp `INNTEKTSMELDING_OMS("Inntektsmelding omsorgspenger")` (skal være støttet av Fager)
- Legger til egen metode for å hente sakstittel for refusjonskrav og for inntektsmelding. 

### **Andre endringer**
- Fjern ubrukt parameter ytelseType i hentPersonInfoFraAktørId og hentPersonFraIdent i PersonTjeneste

