### PR TITLE
TSFF-1742: oppdater etterspurte perioder på forespørsel 

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselEntitet.java
@@ -169,6 +169,15 @@ public class ForespørselEntitet {
             .toList();
     }
 
+    public void setEtterspurtePerioder(List<PeriodeDto> etterspurtePerioder) {
+        if (etterspurtePerioder != null) {
+            this.etterspurtePerioder.clear();
+            etterspurtePerioder.forEach(this::leggTilEtterspurtPeriode);
+        } else {
+            this.etterspurtePerioder = new ArrayList<>();
+        }
+    }
+
     private void leggTilEtterspurtPeriode(PeriodeDto etterspurtPeriode) {
         if (etterspurtePerioderInneholderNyPeriode(etterspurtPeriode)){
             // Dette burde ikke skje, validering skal være gjort i OppdaterForespørselDto

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselEntitet.java
@@ -170,12 +170,11 @@ public class ForespørselEntitet {
     }
 
     public void setEtterspurtePerioder(List<PeriodeDto> etterspurtePerioder) {
-        if (etterspurtePerioder != null) {
-            this.etterspurtePerioder.clear();
-            etterspurtePerioder.forEach(this::leggTilEtterspurtPeriode);
-        } else {
-            this.etterspurtePerioder = new ArrayList<>();
+        if (etterspurtePerioder == null) {
+            throw new IllegalArgumentException("Etterspurte perioder kan ikke være null");
         }
+        this.etterspurtePerioder.clear();
+        etterspurtePerioder.forEach(this::leggTilEtterspurtPeriode);
     }
 
     private void leggTilEtterspurtPeriode(PeriodeDto etterspurtPeriode) {

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -149,4 +149,16 @@ public class ForespørselRepository {
             .setParameter("orgnr", orgnr);
         return query.getResultList();
     }
+
+    public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUUID, List<PeriodeDto> etterspurtePerioder) {
+        var forespørselOpt = hentForespørsel(forespørselUUID);
+        if (forespørselOpt.isPresent()) {
+            var forespørsel = forespørselOpt.get();
+            forespørsel.setEtterspurtePerioder(etterspurtePerioder);
+            entityManager.merge(forespørsel);
+            entityManager.flush();
+        } else {
+            LOG.warn("Forespørsel med UUID {} ble ikke funnet for oppdatering av etterspurte perioder.", forespørselUUID);
+        }
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -150,15 +150,15 @@ public class ForespørselRepository {
         return query.getResultList();
     }
 
-    public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUUID, List<PeriodeDto> etterspurtePerioder) {
-        var forespørselOpt = hentForespørsel(forespørselUUID);
+    public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUuid, List<PeriodeDto> etterspurtePerioder) {
+        var forespørselOpt = hentForespørsel(forespørselUuid);
         if (forespørselOpt.isPresent()) {
             var forespørsel = forespørselOpt.get();
             forespørsel.setEtterspurtePerioder(etterspurtePerioder);
             entityManager.merge(forespørsel);
             entityManager.flush();
         } else {
-            LOG.warn("Forespørsel med UUID {} ble ikke funnet for oppdatering av etterspurte perioder.", forespørselUUID);
+            throw new IllegalStateException("Forventet å finne en forespørsel for oppgitt uuid " + forespørselUuid);
         }
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -51,7 +51,7 @@ public class ForespørselRepository {
         if (forespørselOpt.isPresent()) {
             var forespørsel = forespørselOpt.get();
             forespørsel.setOppgaveId(oppgaveId);
-            entityManager.persist(forespørsel);
+            entityManager.merge(forespørsel);
             entityManager.flush();
         }
     }
@@ -61,7 +61,7 @@ public class ForespørselRepository {
         if (forespørselOpt.isPresent()) {
             var forespørsel = forespørselOpt.get();
             forespørsel.setArbeidsgiverNotifikasjonSakId(arbeidsgiverNotifikasjonSakId);
-            entityManager.persist(forespørsel);
+            entityManager.merge(forespørsel);
             entityManager.flush();
         }
     }
@@ -85,9 +85,9 @@ public class ForespørselRepository {
             .setParameter("SAK_ID", arbeidsgiverNotifikasjonSakId);
         var resultList = query.getResultList();
 
-        resultList.forEach(f -> {
-            f.setStatus(ForespørselStatus.FERDIG);
-            entityManager.persist(f);
+        resultList.forEach(forespørsel -> {
+            forespørsel.setStatus(ForespørselStatus.FERDIG);
+            entityManager.merge(forespørsel);
         });
         entityManager.flush();
     }
@@ -97,9 +97,9 @@ public class ForespørselRepository {
             .setParameter("SAK_ID", arbeidsgiverNotifikasjonSakId);
         var resultList = query.getResultList();
 
-        resultList.forEach(f -> {
-            f.setStatus(ForespørselStatus.UTGÅTT);
-            entityManager.persist(f);
+        resultList.forEach(forespørsel -> {
+            forespørsel.setStatus(ForespørselStatus.UTGÅTT);
+            entityManager.merge(forespørsel);
         });
         entityManager.flush();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -89,4 +89,8 @@ public class ForespørselTjeneste {
     public List<ForespørselEntitet> finnAlleForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
         return forespørselRepository.finnAlleForespørsler(aktørId, ytelsetype, orgnr);
     }
+
+    public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUUID, List<PeriodeDto> etterspurtePerioder) {
+        forespørselRepository.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUUID, etterspurtePerioder);
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -90,7 +90,7 @@ public class ForespørselTjeneste {
         return forespørselRepository.finnAlleForespørsler(aktørId, ytelsetype, orgnr);
     }
 
-    public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUUID, List<PeriodeDto> etterspurtePerioder) {
-        forespørselRepository.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUUID, etterspurtePerioder);
+    public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUuid, List<PeriodeDto> etterspurtePerioder) {
+        forespørselRepository.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
@@ -25,8 +25,8 @@ public class OppdaterForespørselTask implements ProsessTaskHandler {
     private static final Logger LOG = LoggerFactory.getLogger(OppdaterForespørselTask.class);
     private static final ObjectMapper OBJECT_MAPPER = DefaultJsonMapper.getObjectMapper();
 
-    public static final String YTELSETYPE = "ytelsetype";
-    public static final String FORESPØRSEL_UUID = "forespoersel_uuid";
+    static final String FORESPØRSEL_UUID = "forespoersel_uuid";
+    static final String YTELSETYPE = "ytelsetype";
 
     private ForespørselTjeneste forespørselTjeneste;
 
@@ -57,11 +57,6 @@ public class OppdaterForespørselTask implements ProsessTaskHandler {
 
         try {
             etterspurtePerioder = OBJECT_MAPPER.readValue(prosessTaskData.getPayloadAsString(), OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, PeriodeDto.class));
-
-            if (etterspurtePerioder == null) {
-                throw new IllegalStateException("Etterspurte perioder må finnes for oppdatering av forespørsel for OMSORGSPENGER");
-            }
-
             return etterspurtePerioder;
         } catch (Exception e) {
             throw new RuntimeException("Kunne ikke deserialisere etterspurtePerioder", e);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
@@ -25,8 +25,8 @@ public class OppdaterForespørselTask implements ProsessTaskHandler {
     private static final Logger LOG = LoggerFactory.getLogger(OppdaterForespørselTask.class);
     private static final ObjectMapper OBJECT_MAPPER = DefaultJsonMapper.getObjectMapper();
 
-    static final String FORESPØRSEL_UUID = "forespoersel_uuid";
-    static final String YTELSETYPE = "ytelsetype";
+    public static final String FORESPØRSEL_UUID = "forespoersel_uuid";
+    public static final String YTELSETYPE = "ytelsetype";
 
     private ForespørselTjeneste forespørselTjeneste;
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
@@ -1,0 +1,93 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselTjeneste;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
+
+@ApplicationScoped
+@ProsessTask("forespørsel.oppdater")
+public class OppdaterForespørselTask implements ProsessTaskHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(OppdaterForespørselTask.class);
+    private static final ObjectMapper OBJECT_MAPPER = DefaultJsonMapper.getObjectMapper();
+
+    public static final String YTELSETYPE = "ytelsetype";
+    public static final String FORESPØRSEL_UUID = "forespoersel_uuid";
+
+    private ForespørselTjeneste forespørselTjeneste;
+
+    OppdaterForespørselTask() {
+        // CDI
+    }
+
+    @Inject
+    public OppdaterForespørselTask(ForespørselTjeneste forespoerselTjeneste) {
+        this.forespørselTjeneste = forespoerselTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        Ytelsetype ytelseType = Ytelsetype.valueOf(prosessTaskData.getPropertyValue(YTELSETYPE));
+        UUID forespørselUuid = UUID.fromString(prosessTaskData.getPropertyValue(FORESPØRSEL_UUID));
+        List<PeriodeDto> etterspurtePerioder = hentEtterspurtePerioder(prosessTaskData, ytelseType);
+
+        if (ytelseType != Ytelsetype.OMSORGSPENGER) {
+            throw new IllegalStateException("Støtter kun oppdatering av forespørsel for OMSORGSPENGER, fikk: " + ytelseType);
+        }
+
+        if (etterspurtePerioder == null) {
+            throw new IllegalStateException("Etterspurte perioder må finnes for oppdatering av forespørsel for OMSORGSPENGER");
+        }
+
+        // Logikk for oppdatering av forespørsel
+        forespørselTjeneste.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
+    }
+
+    private List<PeriodeDto> hentEtterspurtePerioder(ProsessTaskData prosessTaskData, Ytelsetype ytelsetype) {
+        List<PeriodeDto> etterspurtePerioder;
+        if (ytelsetype != Ytelsetype.OMSORGSPENGER) {
+            return null;
+        }
+
+        try {
+            etterspurtePerioder = OBJECT_MAPPER.readValue(
+                prosessTaskData.getPayloadAsString(),
+                OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, PeriodeDto.class)
+            );
+            return etterspurtePerioder;
+        } catch (Exception e) {
+            throw new RuntimeException("Kunne ikke deserialisere etterspurtePerioder for ytelse: " + ytelsetype, e);
+        }
+    }
+
+    public static ProsessTaskData opprettTaskData(String forespørselUuid,
+                                                  Ytelsetype ytelseType,
+                                                  List<PeriodeDto> etterspurtePerioder) {
+        ProsessTaskData taskData = ProsessTaskData.forProsessTask(OppdaterForespørselTask.class);
+        taskData.setProperty(FORESPØRSEL_UUID, forespørselUuid);
+        taskData.setProperty(YTELSETYPE, ytelseType.name());
+
+        if (etterspurtePerioder != null) {
+            try {
+                taskData.setPayload(OBJECT_MAPPER.writeValueAsString(etterspurtePerioder));
+            } catch (Exception e) {
+                throw new RuntimeException("Kunne ikke serialisere etterspurtePerioder for ytelse: " + ytelseType, e);
+            }
+        }
+        return taskData;
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
@@ -68,11 +68,11 @@ public class OppdaterForespørselTask implements ProsessTaskHandler {
         }
     }
 
-    public static ProsessTaskData opprettTaskData(String forespørselUuid,
-                                                  Ytelsetype ytelseType,
-                                                  List<PeriodeDto> etterspurtePerioder) {
+    public static ProsessTaskData lagOppdaterTaskData(UUID forespørselUuid,
+                                                      Ytelsetype ytelseType,
+                                                      List<PeriodeDto> etterspurtePerioder) {
         ProsessTaskData taskData = ProsessTaskData.forProsessTask(OppdaterForespørselTask.class);
-        taskData.setProperty(FORESPØRSEL_UUID, forespørselUuid);
+        taskData.setProperty(FORESPØRSEL_UUID, forespørselUuid.toString());
         taskData.setProperty(YTELSETYPE, ytelseType.name());
 
         if (etterspurtePerioder != null) {

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -58,7 +58,6 @@ public class OpprettForespørselTask implements ProsessTaskHandler {
 
         List<ForespørselEntitet> eksisterendeForespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(saksnummer, organisasjonsnummer, skjæringstidspunkt);
 
-        // TODO: Sjekk om det er det har kommet nye etterspurtePerioder som ikke er i eksisterende forespørsel. Oppdater i så fall eksisterende forespørsel med nye perioder.
         if (eksisterendeForespørsler.stream().anyMatch(eksisterende -> !eksisterende.getStatus().equals(ForespørselStatus.UTGÅTT))) {
             LOG.info("Forespørsel finnes allerede, orgnr: {}, stp: {}, saksnr: {}, ytelse: {}",
                 organisasjonsnummer.orgnr(), skjæringstidspunkt, saksnummer.saksnr(), ytelsetype);
@@ -88,14 +87,14 @@ public class OpprettForespørselTask implements ProsessTaskHandler {
     }
 
     public static ProsessTaskData lagOpprettForespørselTaskData(Ytelsetype ytelsetype,
-                                                          AktørIdEntitet aktørId,
-                                                          SaksnummerDto saksnummer,
-                                                          OppdaterForespørselDto forespørselDto) {
+                                                                AktørIdEntitet aktørId,
+                                                                SaksnummerDto saksnummer,
+                                                                OppdaterForespørselDto forespørselDto) {
         var taskdata = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
         taskdata.setProperty(OpprettForespørselTask.YTELSETYPE, ytelsetype.name());
         taskdata.setAktørId(aktørId.getAktørId());
         taskdata.setSaksnummer(saksnummer.saksnr());
-        taskdata.setProperty(OpprettForespørselTask.ORGNR,  forespørselDto.orgnr().orgnr());
+        taskdata.setProperty(OpprettForespørselTask.ORGNR, forespørselDto.orgnr().orgnr());
         taskdata.setProperty(OpprettForespørselTask.STP, forespørselDto.skjæringstidspunkt().toString());
         if (forespørselDto.etterspurtePerioder() != null) {
             try {

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/ForespørselOppdatering.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/ForespørselOppdatering.java
@@ -1,0 +1,6 @@
+package no.nav.familie.inntektsmelding.typer.dto;
+
+import java.util.UUID;
+
+public record ForespørselOppdatering(OppdaterForespørselDto oppdaterDto, UUID forespørselUuid) {
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteOppdaterTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteOppdaterTest.java
@@ -1,0 +1,220 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.database.JpaExtension;
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselMapper;
+import no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjon;
+import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.ForespørselAksjon;
+import no.nav.familie.inntektsmelding.typer.dto.OppdaterForespørselDto;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
+
+@ExtendWith({JpaExtension.class, MockitoExtension.class})
+class ForespørselBehandlingTjenesteOppdaterTest extends EntityManagerAwareTest {
+
+    private static final String BRREG_ORGNUMMER = "974760673";
+    private static final String AKTØR_ID = "1234567891234";
+    private static final String SAKSNUMMMER = "FAGSAK_SAKEN";
+    private static final LocalDate STP = LocalDate.now().minusWeeks(4);
+    private static final Ytelsetype YTELSETYPE = Ytelsetype.OMSORGSPENGER;
+
+    @Mock
+    private ForespørselTjeneste forespørselTjeneste;
+    @Mock
+    private ArbeidsgiverNotifikasjon arbeidsgiverNotifikasjon;
+    @Mock
+    private PersonTjeneste personTjeneste;
+    @Mock
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+    @Mock
+    private OrganisasjonTjeneste organisasjonTjeneste;
+
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+
+    @BeforeEach
+    void setUp() {
+        this.forespørselBehandlingTjeneste = new ForespørselBehandlingTjeneste(
+            forespørselTjeneste,
+            arbeidsgiverNotifikasjon,
+            personTjeneste,
+            prosessTaskTjeneste,
+            organisasjonTjeneste
+        );
+    }
+
+    @Test
+    void skal_finne_forespørsel_som_skal_oppdateres_når_etterspurtePerioder_er_forskjellige() {
+        List<PeriodeDto> eksisterendePerioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+        List<PeriodeDto> nyePerioder = List.of(new PeriodeDto(STP, STP.plusDays(10)));
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(nyePerioder);
+
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+        assertThat(forespørslerSomSkalOppdateres.get(0).etterspurtePerioder()).isEqualTo(nyePerioder);
+    }
+
+    @Test
+    void skal_ikke_finne_forespørsel_som_skal_oppdateres_når_etterspurtePerioder_er_like() {
+        List<PeriodeDto> perioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(perioder);
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(perioder);
+
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).isEmpty();
+    }
+
+    @Test
+    void skal_ikke_finne_forespørsel_som_skal_oppdateres_når_kun_rekkefølgen_av_perioder_er_forskjellig() {
+        List<PeriodeDto> eksisterendePerioder = List.of(
+            new PeriodeDto(STP, STP.plusDays(5)),
+            new PeriodeDto(STP.plusWeeks(2), STP.plusWeeks(3))
+        );
+
+        List<PeriodeDto> nyePerioder = List.of(
+            new PeriodeDto(STP.plusWeeks(2), STP.plusWeeks(3)),
+            new PeriodeDto(STP, STP.plusDays(5))
+        );
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(nyePerioder);
+
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto),List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).isEmpty();
+    }
+
+    @Test
+    void skal_finne_forespørsel_som_skal_oppdateres_når_det_er_flere_perioder_enn_før() {
+        List<PeriodeDto> eksisterendePerioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+
+        List<PeriodeDto> nyePerioder = List.of(
+            new PeriodeDto(STP.plusWeeks(2), STP.plusWeeks(3)),
+            new PeriodeDto(STP, STP.plusDays(5))
+        );
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(nyePerioder);
+
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+    }
+
+    @Test
+    void skal_finne_forespørsel_som_skal_oppdateres_når_det_er_færre_perioder_enn_før() {
+        List<PeriodeDto> eksisterendePerioder = List.of(
+            new PeriodeDto(STP.plusWeeks(2), STP.plusWeeks(3)),
+            new PeriodeDto(STP, STP.plusDays(5))
+        );
+
+        List<PeriodeDto> nyePerioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(nyePerioder);
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+    }
+
+    @Test
+    void skal_finne_forespørsel_som_skal_oppdateres_når_eksisterende_har_perioder_men_ny_har_ingen() {
+        List<PeriodeDto> eksisterendePerioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+        List<PeriodeDto> nyePerioder = Collections.emptyList();
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(nyePerioder);
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+    }
+
+    @Test
+    void skal_finne_forespørsel_som_skal_oppdateres_når_eksisterende_har_ingen_perioder_men_ny_har_perioder() {
+        List<PeriodeDto> eksisterendePerioder = Collections.emptyList();
+        List<PeriodeDto> nyePerioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(nyePerioder);
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+    }
+
+    @Test
+    void skal_ikke_finne_forespørsel_som_skal_oppdateres_med_ugyldig_status() {
+        List<PeriodeDto> eksisterendePerioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+        List<PeriodeDto> nyePerioder = List.of(new PeriodeDto(STP, STP.plusDays(10)));
+
+        // Sett status til FERDIG, som ikke skal gi treff
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+        eksisterendeForespørsel.setStatus(ForespørselStatus.FERDIG);
+
+        var forespørslerDto = lagForespørselDtoMedStatusOpprett(nyePerioder);
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).isEmpty();
+    }
+
+    @Test
+    void skal_ikke_finne_forespørsel_som_skal_oppdateres_med_annen_aksjon_enn_opprett() {
+        List<PeriodeDto> eksisterendePerioder = List.of(new PeriodeDto(STP, STP.plusDays(5)));
+        List<PeriodeDto> nyePerioder = List.of(new PeriodeDto(STP, STP.plusDays(10)));
+
+        var eksisterendeForespørsel = lagForespørselMedPerioder(eksisterendePerioder);
+
+        // Bruk UTGÅTT som aksjon, som ikke skal gi treff
+        var forespørslerDto = new OppdaterForespørselDto(STP,
+            new OrganisasjonsnummerDto(BRREG_ORGNUMMER),
+            ForespørselAksjon.UTGÅTT,
+            nyePerioder);
+
+        var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
+
+        assertThat(forespørslerSomSkalOppdateres).isEmpty();
+    }
+
+    private ForespørselEntitet lagForespørselMedPerioder(List<PeriodeDto> perioder) {
+        var forespørsel = ForespørselMapper.mapForespørsel(
+            BRREG_ORGNUMMER,
+            STP,
+            AKTØR_ID,
+            YTELSETYPE,
+            SAKSNUMMMER,
+            STP,
+            perioder
+        );
+        forespørsel.setStatus(ForespørselStatus.UNDER_BEHANDLING);
+        return forespørsel;
+    }
+
+    private static OppdaterForespørselDto lagForespørselDtoMedStatusOpprett(List<PeriodeDto> nyePerioder) {
+        return new OppdaterForespørselDto(STP,
+            new OrganisasjonsnummerDto(BRREG_ORGNUMMER),
+            ForespørselAksjon.OPPRETT,
+            nyePerioder
+        );
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteOppdaterTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteOppdaterTest.java
@@ -71,7 +71,7 @@ class ForespørselBehandlingTjenesteOppdaterTest extends EntityManagerAwareTest 
         var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
 
         assertThat(forespørslerSomSkalOppdateres).hasSize(1);
-        assertThat(forespørslerSomSkalOppdateres.get(0).etterspurtePerioder()).isEqualTo(nyePerioder);
+        assertThat(forespørslerSomSkalOppdateres.getFirst().oppdaterDto().etterspurtePerioder()).isEqualTo(nyePerioder);
     }
 
     @Test
@@ -137,6 +137,7 @@ class ForespørselBehandlingTjenesteOppdaterTest extends EntityManagerAwareTest 
         var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
 
         assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+        assertThat(forespørslerSomSkalOppdateres.getFirst().oppdaterDto().etterspurtePerioder()).isEqualTo(nyePerioder);
     }
 
     @Test
@@ -149,6 +150,7 @@ class ForespørselBehandlingTjenesteOppdaterTest extends EntityManagerAwareTest 
         var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
 
         assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+        assertThat(forespørslerSomSkalOppdateres.getFirst().oppdaterDto().etterspurtePerioder()).isEqualTo(nyePerioder);
     }
 
     @Test
@@ -161,6 +163,7 @@ class ForespørselBehandlingTjenesteOppdaterTest extends EntityManagerAwareTest 
         var forespørslerSomSkalOppdateres = forespørselBehandlingTjeneste.utledForespørslerSomSkalOppdateres(List.of(forespørslerDto), List.of(eksisterendeForespørsel));
 
         assertThat(forespørslerSomSkalOppdateres).hasSize(1);
+        assertThat(forespørslerSomSkalOppdateres.getFirst().oppdaterDto().etterspurtePerioder()).isEqualTo(nyePerioder);
     }
 
     @Test

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
@@ -213,7 +213,7 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
     }
 
     @Test
-    void skal_oppdatere_forespørsel_dersom_det_eksisterer_en_for_samme_stp_men_med_andre_eksisterende_perioder() throws Exception {
+    void skal_oppdatere_forespørsel_for_omsorgspenger_dersom_det_eksisterer_en_for_samme_stp_men_med_andre_eksisterende_perioder() throws Exception {
         var etterspurtePerioder = List.of(new PeriodeDto(SKJÆRINGSTIDSPUNKT, SKJÆRINGSTIDSPUNKT.plusDays(10)));
         var forespørselUuid = forespørselRepository.lagreForespørsel(SKJÆRINGSTIDSPUNKT, Ytelsetype.OMSORGSPENGER, AKTØR_ID, BRREG_ORGNUMMER, SAKSNUMMMER, SKJÆRINGSTIDSPUNKT, etterspurtePerioder);
         forespørselRepository.oppdaterArbeidsgiverNotifikasjonSakId(forespørselUuid, SAK_ID);

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTaskTest.java
@@ -1,0 +1,100 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselTjeneste;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
+
+class OppdaterForespørselTaskTest {
+
+    private ForespørselTjeneste forespørselTjeneste;
+    private OppdaterForespørselTask task;
+    private UUID forespørselUuid;
+    private List<PeriodeDto> etterspurtePerioder;
+    private static final ObjectMapper OBJECT_MAPPER = DefaultJsonMapper.getObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        forespørselTjeneste = Mockito.mock(ForespørselTjeneste.class);
+        task = new OppdaterForespørselTask(forespørselTjeneste);
+        forespørselUuid = UUID.randomUUID();
+
+        // Oppretter test perioder
+        etterspurtePerioder = List.of(
+            new PeriodeDto(LocalDate.now(), LocalDate.now().plusDays(10)),
+            new PeriodeDto(LocalDate.now().plusDays(20), LocalDate.now().plusDays(30))
+        );
+    }
+
+    @Test
+    void skal_oppdatere_forespørsel_med_nye_perioder() throws Exception {
+        // Arrange
+        var taskdata = OppdaterForespørselTask.lagOppdaterTaskData(forespørselUuid, Ytelsetype.OMSORGSPENGER, etterspurtePerioder);
+
+        // Act
+        task.doTask(taskdata);
+
+        // Assert
+        verify(forespørselTjeneste).oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
+    }
+
+    @Test
+    void skal_kaste_feil_når_ytelsetype_ikke_er_omsorgspenger() {
+        // Arrange
+        var taskdata = OppdaterForespørselTask.lagOppdaterTaskData(forespørselUuid, Ytelsetype.PLEIEPENGER_SYKT_BARN, etterspurtePerioder);
+
+        // Act & Assert
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> task.doTask(taskdata));
+        assertEquals("Støtter kun oppdatering av forespørsel for OMSORGSPENGER, fikk: PLEIEPENGER_SYKT_BARN", exception.getMessage());
+        verifyNoInteractions(forespørselTjeneste);
+    }
+
+    @Test
+    void skal_kaste_feil_når_etterspurte_perioder_er_null() throws Exception {
+        // Arrange
+        var taskdata = OppdaterForespørselTask.lagOppdaterTaskData(forespørselUuid, Ytelsetype.OMSORGSPENGER, null);
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> task.doTask(taskdata));
+        assertEquals("Kunne ikke deserialisere etterspurtePerioder", exception.getMessage());
+        verifyNoInteractions(forespørselTjeneste);
+    }
+
+    @Test
+    void skal_lage_riktig_taskdata() throws Exception {
+        // Act
+        var taskdata = OppdaterForespørselTask.lagOppdaterTaskData(
+            forespørselUuid,
+            Ytelsetype.OMSORGSPENGER,
+            etterspurtePerioder
+        );
+
+        // Assert
+        assertEquals(forespørselUuid.toString(), taskdata.getPropertyValue(OppdaterForespørselTask.FORESPØRSEL_UUID));
+        assertEquals(Ytelsetype.OMSORGSPENGER.name(), taskdata.getPropertyValue(OppdaterForespørselTask.YTELSETYPE));
+
+        // Verifiser at payload inneholder riktige perioder
+        List<PeriodeDto> deserialisertePerioder = OBJECT_MAPPER.readValue(
+            taskdata.getPayloadAsString(),
+            OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, PeriodeDto.class)
+        );
+        assertEquals(etterspurtePerioder.size(), deserialisertePerioder.size());
+        assertEquals(etterspurtePerioder.get(0).fom(), deserialisertePerioder.get(0).fom());
+        assertEquals(etterspurtePerioder.get(0).tom(), deserialisertePerioder.get(0).tom());
+    }
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å vise frem riktige perioder til arbeidsgiver når de fyller ut inntektsmeldingen må vi oppdatere forespørslene med riktig etterspurte perioder. 

Jira: https://jira.adeo.no/browse/TSFF-1742

### **Løsning**
Oppretter `OppdaterForespørselTask` som kun skal oppdatere etterspurte perioder dersom følgene krav er oppfylt:
1. `ytelseType = OMSORGSPENGER`
2. ForespørselDto-en har status `OPPRETT`
3. Den eksisterende forespørsel entiteten har status `UNDER_BEHANDLING`
4. De har forskjellige etterspurte perioder. Hvis de er forskjellige skal vi overskrive med de nye periodene vi får fra k9-sak

### **Andre endringer**
- Endrer fra entityManager.persist til entityManager.merge der vi skal gjøre oppdateringer i databasen
