### PR TITLE
TSFF-1742: Oppdater etterspurte perioder også ved forespørsel aksjon == BEHOLD

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -182,7 +182,7 @@ public class ForespørselBehandlingTjeneste {
         }
 
         return forespørselDtoer.stream()
-            .filter(forespørselDto -> forespørselDto.aksjon() == ForespørselAksjon.OPPRETT) // Kun oppdater forespørsler med OPPRETT-aksjon
+            .filter(forespørselDto -> forespørselDto.aksjon() == ForespørselAksjon.OPPRETT || forespørselDto.aksjon() == ForespørselAksjon.BEHOLD)
             .map(forespørselDto -> {
                 Optional<ForespørselEntitet> eksisterendeForespørselEntitet = finnEksisterendeForespørselMedUlikEtterspurtePerioder(forespørselDto, eksisterendeForespørsler);
                 return eksisterendeForespørselEntitet.map(forspørsel -> new ForespørselOppdatering(forespørselDto, forspørsel.getUuid())).orElse(null);


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å vise frem riktige perioder til arbeidsgiver når de fyller ut inntektsmeldingen må vi oppdatere forespørslene med riktig etterspurte perioder. 

I PRen https://github.com/navikt/k9-inntektsmelding/pull/486 la vi til støtte for å oppdatere etterspurte perioder for forespørsler med aksjonstatus OPPRETT. Vi ønsker å oppdatere også ved BEHOLD

Jira: https://jira.adeo.no/browse/TSFF-1742


### **Løsning**
Oppdaterer også ved `forespørsel.aksjonstatus == BEHOLD`