### PR TITLE
TSFF-1852: Oppdater tilleggsinformasjonen med nye antall fraværsdager

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -257,6 +257,17 @@ public class ForespørselBehandlingTjeneste {
                 forespørselDto.skjæringstidspunkt().equals(eksisterendeForespørsel.getSkjæringstidspunkt()));
     }
 
+    public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUuid, List<PeriodeDto> etterspurtePerioder) {
+        ForespørselEntitet forespørsel = forespørselTjeneste.hentForespørsel(forespørselUuid)
+            .orElseThrow(() -> new IllegalStateException("Finner ikke forespørsel for UUID: " + forespørselUuid));
+
+        arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(forespørsel.getArbeidsgiverNotifikasjonSakId(),
+            ForespørselTekster.lagTilleggsInformasjonForOmsorgspenger(etterspurtePerioder));
+
+        LOG.info("Oppdaterer forespørsel med nye etterspurte perioder, uuid: {}, perioder: {}", forespørselUuid, etterspurtePerioder);
+        forespørselTjeneste.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
+    }
+
     public void settForespørselTilUtgått(ForespørselEntitet eksisterendeForespørsel, boolean skalOppdatereArbeidsgiverNotifikasjon) {
         if (skalOppdatereArbeidsgiverNotifikasjon) {
             eksisterendeForespørsel.getOppgaveId().ifPresent(oppgaveId -> arbeidsgiverNotifikasjon.oppgaveUtgått(oppgaveId, OffsetDateTime.now()));

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTask.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselTjeneste;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
@@ -28,15 +28,15 @@ public class OppdaterForespørselTask implements ProsessTaskHandler {
     public static final String FORESPØRSEL_UUID = "forespoersel_uuid";
     public static final String YTELSETYPE = "ytelsetype";
 
-    private ForespørselTjeneste forespørselTjeneste;
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
 
     OppdaterForespørselTask() {
         // CDI
     }
 
     @Inject
-    public OppdaterForespørselTask(ForespørselTjeneste forespoerselTjeneste) {
-        this.forespørselTjeneste = forespoerselTjeneste;
+    public OppdaterForespørselTask(ForespørselBehandlingTjeneste forespørselBehandlingTjeneste) {
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
     }
 
     @Override
@@ -49,7 +49,7 @@ public class OppdaterForespørselTask implements ProsessTaskHandler {
 
         UUID forespørselUuid = UUID.fromString(prosessTaskData.getPropertyValue(FORESPØRSEL_UUID));
         List<PeriodeDto> etterspurtePerioder = hentEtterspurtePerioder(prosessTaskData);
-        forespørselTjeneste.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
+        forespørselBehandlingTjeneste.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
     }
 
     private List<PeriodeDto> hentEtterspurtePerioder(ProsessTaskData prosessTaskData) {

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OppdaterForespørselTaskTest.java
@@ -15,14 +15,14 @@ import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselTjeneste;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 class OppdaterForespørselTaskTest {
 
-    private ForespørselTjeneste forespørselTjeneste;
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
     private OppdaterForespørselTask task;
     private UUID forespørselUuid;
     private List<PeriodeDto> etterspurtePerioder;
@@ -30,8 +30,8 @@ class OppdaterForespørselTaskTest {
 
     @BeforeEach
     void setUp() {
-        forespørselTjeneste = Mockito.mock(ForespørselTjeneste.class);
-        task = new OppdaterForespørselTask(forespørselTjeneste);
+        forespørselBehandlingTjeneste = Mockito.mock(ForespørselBehandlingTjeneste.class);
+        task = new OppdaterForespørselTask(forespørselBehandlingTjeneste);
         forespørselUuid = UUID.randomUUID();
 
         // Oppretter test perioder
@@ -50,7 +50,7 @@ class OppdaterForespørselTaskTest {
         task.doTask(taskdata);
 
         // Assert
-        verify(forespørselTjeneste).oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
+        verify(forespørselBehandlingTjeneste).oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
     }
 
     @Test
@@ -61,7 +61,7 @@ class OppdaterForespørselTaskTest {
         // Act & Assert
         IllegalStateException exception = assertThrows(IllegalStateException.class, () -> task.doTask(taskdata));
         assertEquals("Støtter kun oppdatering av forespørsel for OMSORGSPENGER, fikk: PLEIEPENGER_SYKT_BARN", exception.getMessage());
-        verifyNoInteractions(forespørselTjeneste);
+        verifyNoInteractions(forespørselBehandlingTjeneste);
     }
 
     @Test
@@ -72,7 +72,7 @@ class OppdaterForespørselTaskTest {
         // Act & Assert
         RuntimeException exception = assertThrows(RuntimeException.class, () -> task.doTask(taskdata));
         assertEquals("Kunne ikke deserialisere etterspurtePerioder", exception.getMessage());
-        verifyNoInteractions(forespørselTjeneste);
+        verifyNoInteractions(forespørselBehandlingTjeneste);
     }
 
     @Test


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dersom bruker søker om nye perioder innenfor 4 uker fra skjæringstidspunkt, skal vi oppdatere forespørselen med de nye periodene. Da må også tilleggsinformasjonen oppdateres. 

Jira: https://jira.adeo.no/browse/TSFF-1852

### **Løsning**
Oppdaterer tilleggsinformasjonen ved oppdatering av forespørsel.
