### PR TITLE
TSFF-1876: Lag tilleggsinfo med fra dato og til dato for inntektsmelding for omsorgspenger

### DIFF
--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTeksterTest.java
@@ -64,7 +64,25 @@ class ForespørselTeksterTest {
             new DelvisFraværsPeriodeEntitet(LocalDate.of(2025, 3, 23), BigDecimal.valueOf(2)),
             new DelvisFraværsPeriodeEntitet(LocalDate.of(2025, 4, 2), BigDecimal.valueOf(4)));
         String statusTekst = ForespørselTekster.lagTilleggsInformasjonForOmsorgspenger(fraværsPerioder, delvisFravær);
-        var forventetTekst = "For 7 dager i mars, 1 dag i april.";
+        var forventetTekst = "For 7 dager i mars, 1 dag i april";
+        assertEquals(forventetTekst, statusTekst);
+    }
+
+    @Test
+    void lagTilleggsInformasjon_OmsorgspengerRefusjon_1_etterspurt_periode_dag() {
+        List<PeriodeDto> etterspurtePerioder = List.of(
+            new PeriodeDto(LocalDate.of(2025, 4, 2), LocalDate.of(2025, 4, 2)));
+        String statusTekst = ForespørselTekster.lagTilleggsInformasjonForOmsorgspenger(etterspurtePerioder);
+        var forventetTekst = "For fraværsdag 02.04.25";
+        assertEquals(forventetTekst, statusTekst);
+    }
+
+    @Test
+    void lagTilleggsInformasjon_OmsorgspengerRefusjon_1_etterspurt_periode() {
+        List<PeriodeDto> etterspurtePerioder = List.of(
+            new PeriodeDto(LocalDate.of(2025, 4, 2), LocalDate.of(2025, 4, 5)));
+        String statusTekst = ForespørselTekster.lagTilleggsInformasjonForOmsorgspenger(etterspurtePerioder);
+        var forventetTekst = "For fraværsperiode 02.04.25–05.04.25";
         assertEquals(forventetTekst, statusTekst);
     }
 
@@ -75,7 +93,7 @@ class ForespørselTeksterTest {
             new PeriodeDto(LocalDate.of(2025, 3, 29), LocalDate.of(2025, 3, 31)),
             new PeriodeDto(LocalDate.of(2025, 4, 2), LocalDate.of(2025, 4, 2)));
         String statusTekst = ForespørselTekster.lagTilleggsInformasjonForOmsorgspenger(etterspurtePerioder);
-        var forventetTekst = "For 6 dager i mars, 1 dag i april.";
+        var forventetTekst = "For 6 dager i mars, 1 dag i april";
         assertEquals(forventetTekst, statusTekst);
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Når vi oppretter forespørsel for inntektsmelding omsorgspenger har vi info om hvilke perioder inntektsmeldingen dekker, og hvor mange dager og perioder det er snakk om. For omsorgspenger oppretter vi også forespørsel for hver nye periode. Det gjør at vi må være tydelige på hvilke dager og perioder det er snakk om. 

Ønsker å forenkle for refusjonskrav også.

Jira: https://jira.adeo.no/browse/TSFF-1876

### **Løsning**
Lag tilpassede tekster for én fraværdag og én fraværsperiode. Bruker gammel logikk dersom de er mer.
