### PR TITLE
Chore: rydder i inntektsmelding tjeneste

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -54,8 +54,8 @@ public class ArbeidsgiverinitiertDialogRest {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
         LOG.info("Henter arbeidsforhold for søker");
-        var dto = inntektsmeldingTjeneste.finnArbeidsforholdForFnr(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag());
-        return dto.map(d ->Response.ok(d).build()).orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
+        var response = inntektsmeldingTjeneste.finnArbeidsforholdForFnr(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag());
+        return response.map(d ->Response.ok(d).build()).orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
     @POST
@@ -67,7 +67,7 @@ public class ArbeidsgiverinitiertDialogRest {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
         LOG.info("Henter opplysninger for søker");
-        var dto = inntektsmeldingTjeneste.lagArbeidsgiverinitiertDialogDto(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag(), request.organisasjonsnummer());
-        return Response.ok(dto).build();
+        var hentOpplysningerResponse = inntektsmeldingTjeneste.hentOpplysninger(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag(), request.organisasjonsnummer());
+        return Response.ok(hentOpplysningerResponse).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentOpplysningerResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentOpplysningerResponse.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+
 import no.nav.familie.inntektsmelding.typer.dto.ForespørselStatusDto;
 import no.nav.familie.inntektsmelding.typer.dto.InnsenderDto;
 import no.nav.familie.inntektsmelding.typer.dto.InntektsopplysningerDto;
@@ -14,7 +15,7 @@ import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.dto.PersonInfoDto;
 import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
 
-public record InntektsmeldingDialogDto(@Valid @NotNull PersonInfoDto person,
+public record HentOpplysningerResponse(@Valid @NotNull PersonInfoDto person,
                                        @Valid @NotNull OrganisasjonInfoDto arbeidsgiver,
                                        @Valid @NotNull InnsenderDto innsender,
                                        @Valid @NotNull InntektsopplysningerDto inntektsopplysninger,

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogDto.java
@@ -1,20 +1,21 @@
 package no.nav.familie.inntektsmelding.imdialog.rest;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-
 import no.nav.familie.inntektsmelding.typer.dto.ForespørselStatusDto;
-import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
+import no.nav.familie.inntektsmelding.typer.dto.InnsenderDto;
+import no.nav.familie.inntektsmelding.typer.dto.InntektsopplysningerDto;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonInfoDto;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.familie.inntektsmelding.typer.dto.PersonInfoDto;
 import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
 
-public record InntektsmeldingDialogDto(@Valid @NotNull PersonInfoResponseDto person,
-                                       @Valid @NotNull OrganisasjonInfoResponseDto arbeidsgiver,
+public record InntektsmeldingDialogDto(@Valid @NotNull PersonInfoDto person,
+                                       @Valid @NotNull OrganisasjonInfoDto arbeidsgiver,
                                        @Valid @NotNull InnsenderDto innsender,
                                        @Valid @NotNull InntektsopplysningerDto inntektsopplysninger,
                                        @Valid @NotNull LocalDate skjæringstidspunkt,
@@ -23,19 +24,4 @@ public record InntektsmeldingDialogDto(@Valid @NotNull PersonInfoResponseDto per
                                        @Valid @NotNull ForespørselStatusDto forespørselStatus,
                                        @Valid @NotNull LocalDate førsteUttaksdato,
                                        @Valid List<PeriodeDto> etterspurtePerioder) {
-
-    public record PersonInfoResponseDto(@NotNull String fornavn, @NotNull String mellomnavn, @NotNull String etternavn, @NotNull String fødselsnummer,
-                                        @NotNull String aktørId) {
-    }
-
-    public record OrganisasjonInfoResponseDto(@NotNull String organisasjonNavn, @NotNull String organisasjonNummer) {
-    }
-
-    public record InnsenderDto(@NotNull String fornavn, String mellomnavn, @NotNull String etternavn, String telefon) {
-    }
-
-    public record InntektsopplysningerDto(@Valid BigDecimal gjennomsnittLønn, @NotNull @Valid List<MånedsinntektDto> månedsinntekter) {
-        public record MånedsinntektDto(@NotNull LocalDate fom, @NotNull LocalDate tom, BigDecimal beløp, @Valid @NotNull MånedslønnStatus status) {
-        }
-    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -71,7 +71,7 @@ public class InntektsmeldingDialogRest {
         tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(forespørselUuid);
 
         LOG.info("Henter forespørsel med uuid {}", forespørselUuid);
-        var dto = inntektsmeldingTjeneste.lagDialogDto(forespørselUuid);
+        var dto = inntektsmeldingTjeneste.hentOpplysninger(forespørselUuid);
         return Response.ok(dto).build();
 
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -18,18 +18,17 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import no.nav.familie.inntektsmelding.koder.Ytelsetype;
-import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
-
-import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.familie.inntektsmelding.imdialog.tjenester.InntektsmeldingMottakTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.tjenester.InntektsmeldingTjeneste;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedTokenX;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 
 @AutentisertMedTokenX
 @RequestScoped
@@ -48,6 +47,7 @@ public class InntektsmeldingDialogRest {
     private static final String LAST_NED_PDF = "/last-ned-pdf";
 
     private InntektsmeldingTjeneste inntektsmeldingTjeneste;
+    private InntektsmeldingMottakTjeneste inntektsmeldingMottakTjeneste;
     private Tilgang tilgang;
 
     InntektsmeldingDialogRest() {
@@ -55,8 +55,11 @@ public class InntektsmeldingDialogRest {
     }
 
     @Inject
-    public InntektsmeldingDialogRest(InntektsmeldingTjeneste inntektsmeldingTjeneste, Tilgang tilgang) {
+    public InntektsmeldingDialogRest(InntektsmeldingTjeneste inntektsmeldingTjeneste,
+                                     InntektsmeldingMottakTjeneste inntektsmeldingMottakTjeneste,
+                                     Tilgang tilgang) {
         this.inntektsmeldingTjeneste = inntektsmeldingTjeneste;
+        this.inntektsmeldingMottakTjeneste = inntektsmeldingMottakTjeneste;
         this.tilgang = tilgang;
     }
 
@@ -112,7 +115,7 @@ public class InntektsmeldingDialogRest {
     public Response sendInntektsmelding(@NotNull @Valid SendInntektsmeldingRequestDto sendInntektsmeldingRequestDto) {
         tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(sendInntektsmeldingRequestDto.foresporselUuid());
         LOG.info("Mottok inntektsmelding for forespørsel {}", sendInntektsmeldingRequestDto.foresporselUuid());
-        return Response.ok(inntektsmeldingTjeneste.mottaInntektsmelding(sendInntektsmeldingRequestDto)).build();
+        return Response.ok(inntektsmeldingMottakTjeneste.mottaInntektsmelding(sendInntektsmeldingRequestDto)).build();
     }
 
     @POST
@@ -122,7 +125,7 @@ public class InntektsmeldingDialogRest {
     public Response sendInntektsmeldingForOmsorgspengerRefusjon(@NotNull @Valid SendInntektsmeldingRequestDto sendInntektsmeldingRequestDto) {
         tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(new OrganisasjonsnummerDto(sendInntektsmeldingRequestDto.arbeidsgiverIdent().ident()));
         LOG.info("Mottok inntektsmelding for omsorgspenger refusjon for aktørId {}", sendInntektsmeldingRequestDto.aktorId());
-        return Response.ok(inntektsmeldingTjeneste.mottaInntektsmeldingForOmsorgspengerRefusjon(sendInntektsmeldingRequestDto)).build();
+        return Response.ok(inntektsmeldingMottakTjeneste.mottaInntektsmeldingForOmsorgspengerRefusjon(sendInntektsmeldingRequestDto)).build();
 
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
@@ -1,0 +1,131 @@
+package no.nav.familie.inntektsmelding.imdialog.tjenester;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.LukkeÅrsak;
+import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
+import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingResponseDto;
+import no.nav.familie.inntektsmelding.imdialog.rest.SendInntektsmeldingRequestDto;
+import no.nav.familie.inntektsmelding.imdialog.task.SendTilJoarkTask;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.metrikker.MetrikkerTjeneste;
+import no.nav.familie.inntektsmelding.typer.dto.KodeverkMapper;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@ApplicationScoped
+public class InntektsmeldingMottakTjeneste {
+    private static final Logger LOG = LoggerFactory.getLogger(InntektsmeldingMottakTjeneste.class);
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+    private InntektsmeldingRepository inntektsmeldingRepository;
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+
+    InntektsmeldingMottakTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public InntektsmeldingMottakTjeneste(ForespørselBehandlingTjeneste forespørselBehandlingTjeneste,
+                                         InntektsmeldingRepository inntektsmeldingRepository,
+                                         ProsessTaskTjeneste prosessTaskTjeneste) {
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+        this.inntektsmeldingRepository = inntektsmeldingRepository;
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
+    }
+
+    public InntektsmeldingResponseDto mottaInntektsmelding(SendInntektsmeldingRequestDto mottattInntektsmeldingDto) {
+        var forespørselEntitet = forespørselBehandlingTjeneste.hentForespørsel(mottattInntektsmeldingDto.foresporselUuid())
+            .orElseThrow(() -> new IllegalStateException("Mangler forespørsel entitet"));
+
+        if (ForespørselStatus.UTGÅTT.equals(forespørselEntitet.getStatus())) {
+            throw new IllegalStateException("Kan ikke motta nye inntektsmeldinger på utgåtte forespørsler");
+        }
+
+        var aktorId = new AktørIdEntitet(mottattInntektsmeldingDto.aktorId().id());
+        var orgnummer = new OrganisasjonsnummerDto(mottattInntektsmeldingDto.arbeidsgiverIdent().ident());
+        var entitet = InntektsmeldingMapper.mapTilEntitet(mottattInntektsmeldingDto, forespørselEntitet);
+        var imId = lagreOgLagJournalførTask(entitet, forespørselEntitet);
+
+        List<FraværsPeriodeEntitet> omsorgspengerFraværsPerioder = entitet.getOmsorgspenger() != null
+            ? entitet.getOmsorgspenger().getFraværsPerioder()
+            : List.of();
+
+        List<DelvisFraværsPeriodeEntitet> omsorgspengerDelvisFraværsPerioder = entitet.getOmsorgspenger() != null
+            ? entitet.getOmsorgspenger().getDelvisFraværsPerioder()
+            : List.of();
+
+        var lukketForespørsel = forespørselBehandlingTjeneste.ferdigstillForespørsel(mottattInntektsmeldingDto.foresporselUuid(), aktorId, orgnummer,
+            LukkeÅrsak.ORDINÆR_INNSENDING, omsorgspengerFraværsPerioder, omsorgspengerDelvisFraværsPerioder);
+
+        var imEntitet = inntektsmeldingRepository.hentInntektsmelding(imId);
+
+        // Metrikker i prometheus
+        MetrikkerTjeneste.loggForespørselLukkIntern(lukketForespørsel);
+        MetrikkerTjeneste.loggInnsendtInntektsmelding(imEntitet);
+
+        return InntektsmeldingMapper.mapFraEntitet(imEntitet, mottattInntektsmeldingDto.foresporselUuid());
+    }
+
+    public InntektsmeldingResponseDto mottaInntektsmeldingForOmsorgspengerRefusjon(SendInntektsmeldingRequestDto sendInntektsmeldingRequestDto) {
+        var ytelseType = KodeverkMapper.mapYtelsetype(sendInntektsmeldingRequestDto.ytelse());
+        if (ytelseType != Ytelsetype.OMSORGSPENGER) {
+            throw new IllegalArgumentException("Feil ytelseType for inntektsmelding for omsorgspenger refusjon, ytelsetype var " + ytelseType);
+        }
+
+        var aktørId = new AktørIdEntitet(sendInntektsmeldingRequestDto.aktorId().id());
+        var organisasjonsnummer = new OrganisasjonsnummerDto(sendInntektsmeldingRequestDto.arbeidsgiverIdent().ident());
+
+        var forespørselUuid = forespørselBehandlingTjeneste.opprettForespørselForOmsorgspengerRefusjonIm(
+            aktørId,
+            organisasjonsnummer,
+            sendInntektsmeldingRequestDto.startdato());
+
+        var forespørselEnitet = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
+            .orElseThrow(() -> new IllegalStateException("Mangler forespørsel entitet"));
+
+        var imEnitet = InntektsmeldingMapper.mapTilEntitet(sendInntektsmeldingRequestDto, forespørselEnitet);
+        var imId = lagreOgLagJournalførTask(imEnitet, forespørselEnitet);
+
+        forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid, aktørId, organisasjonsnummer,
+            LukkeÅrsak.ORDINÆR_INNSENDING, imEnitet.getOmsorgspenger().getFraværsPerioder(), imEnitet.getOmsorgspenger().getDelvisFraværsPerioder());
+
+        var imEntitet = inntektsmeldingRepository.hentInntektsmelding(imId);
+
+        // Metrikker i prometheus
+        MetrikkerTjeneste.logginnsendtImOmsorgspengerRefusjon(imEntitet);
+
+        return InntektsmeldingMapper.mapFraEntitet(imEntitet, forespørselUuid);
+    }
+
+    private Long lagreOgLagJournalførTask(InntektsmeldingEntitet inntektsmeldingEntitet, ForespørselEntitet forespørsel) {
+        var ytelseType = inntektsmeldingEntitet.getYtelsetype();
+        LOG.info("Lagrer inntektsmelding for for ytelse {} og fagsak saksnummer {}", ytelseType, forespørsel.getSaksnummer().orElse(null));
+
+        var imId = inntektsmeldingRepository.lagreInntektsmelding(inntektsmeldingEntitet);
+        opprettTaskForSendTilJoark(imId, ytelseType, forespørsel);
+        return imId;
+    }
+
+    private void opprettTaskForSendTilJoark(Long imId, Ytelsetype ytelsetype, ForespørselEntitet forespørsel) {
+        var task = ProsessTaskData.forProsessTask(SendTilJoarkTask.class);
+
+        forespørsel.getSaksnummer().ifPresent(task::setSaksnummer);
+        task.setProperty(SendTilJoarkTask.KEY_INNTEKTSMELDING_ID, imId.toString());
+        task.setProperty(SendTilJoarkTask.KEY_YTELSE_TYPE, ytelsetype.toString());
+        prosessTaskTjeneste.lagre(task);
+        LOG.info("Opprettet task for oversending til joark");
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
-import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingDialogDto;
+import no.nav.familie.inntektsmelding.imdialog.rest.HentOpplysningerResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingResponseDto;
 import no.nav.familie.inntektsmelding.imdialog.rest.SlåOppArbeidstakerResponseDto;
 import no.nav.familie.inntektsmelding.integrasjoner.dokgen.K9DokgenTjeneste;
@@ -68,7 +68,7 @@ public class InntektsmeldingTjeneste {
         this.arbeidstakerTjeneste = arbeidstakerTjeneste;
     }
 
-    public InntektsmeldingDialogDto lagDialogDto(UUID forespørselUuid) {
+    public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
         var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
             .orElseThrow(() -> new IllegalStateException(
                 "Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
@@ -80,7 +80,7 @@ public class InntektsmeldingTjeneste {
             forespørsel.getSkjæringstidspunkt(),
             forespørsel.getOrganisasjonsnummer());
 
-        return new InntektsmeldingDialogDto(personInfo,
+        return new HentOpplysningerResponse(personInfo,
             organisasjonInfo,
             innsender,
             inntektsopplysninger,
@@ -92,10 +92,10 @@ public class InntektsmeldingTjeneste {
             forespørsel.getEtterspurtePerioder());
     }
 
-    public InntektsmeldingDialogDto lagArbeidsgiverinitiertDialogDto(PersonIdent fødselsnummer,
-                                                                     Ytelsetype ytelsetype,
-                                                                     LocalDate førsteFraværsdag,
-                                                                     OrganisasjonsnummerDto organisasjonsnummer) {
+    public HentOpplysningerResponse hentOpplysninger(PersonIdent fødselsnummer,
+                                                     Ytelsetype ytelsetype,
+                                                     LocalDate førsteFraværsdag,
+                                                     OrganisasjonsnummerDto organisasjonsnummer) {
         var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
 
         var eksisterendeForepørsler = forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(personInfo.aktørId(),
@@ -108,14 +108,14 @@ public class InntektsmeldingTjeneste {
 
         if (!forespørslerSomMatcherFraværsdag.isEmpty()) {
             var forespørsel = forespørslerSomMatcherFraværsdag.getFirst();
-            return lagDialogDto(forespørsel.getUuid());
+            return hentOpplysninger(forespørsel.getUuid());
         }
 
         var personDto = new PersonInfoDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(), personInfo.fødselsnummer().getIdent(), personInfo.aktørId().getAktørId());
         var organisasjonInfo = finnOrganisasjonInfo(organisasjonsnummer.orgnr());
         var innsender = finnInnsender();
         var inntektsopplysninger = finnInntektsopplysninger(null, personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr());
-        return new InntektsmeldingDialogDto(personDto,
+        return new HentOpplysningerResponse(personDto,
             organisasjonInfo,
             innsender,
             inntektsopplysninger,

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/InnsenderDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/InnsenderDto.java
@@ -1,0 +1,6 @@
+package no.nav.familie.inntektsmelding.typer.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record InnsenderDto(@NotNull String fornavn, String mellomnavn, @NotNull String etternavn, String telefon) {
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/InntektsopplysningerDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/InntektsopplysningerDto.java
@@ -1,0 +1,10 @@
+package no.nav.familie.inntektsmelding.typer.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record InntektsopplysningerDto(@Valid BigDecimal gjennomsnittLønn, @NotNull @Valid List<MånedsinntektDto> månedsinntekter) {
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/MånedsinntektDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/MånedsinntektDto.java
@@ -1,0 +1,10 @@
+package no.nav.familie.inntektsmelding.typer.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record MånedsinntektDto(@NotNull LocalDate fom, @NotNull LocalDate tom, BigDecimal beløp, @Valid @NotNull MånedslønnStatus status) {
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/OrganisasjonInfoDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/OrganisasjonInfoDto.java
@@ -1,0 +1,7 @@
+package no.nav.familie.inntektsmelding.typer.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OrganisasjonInfoDto(@NotNull String organisasjonNavn,
+                                  @NotNull String organisasjonNummer) {
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/PersonInfoDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/PersonInfoDto.java
@@ -1,0 +1,10 @@
+package no.nav.familie.inntektsmelding.typer.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PersonInfoDto(@NotNull String fornavn,
+                            @NotNull String mellomnavn,
+                            @NotNull String etternavn,
+                            @NotNull String fødselsnummer,
+                            @NotNull String aktørId) {
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjenesteTest.java
@@ -1,0 +1,101 @@
+package no.nav.familie.inntektsmelding.imdialog.tjenester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselMapper;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
+import no.nav.familie.inntektsmelding.imdialog.rest.SendInntektsmeldingRequestDto;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.AktørIdDto;
+import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
+import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
+import no.nav.vedtak.sikkerhet.kontekst.RequestKontekst;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
+import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
+import no.nav.vedtak.sikkerhet.oidc.token.TokenString;
+
+@ExtendWith(MockitoExtension.class)
+class InntektsmeldingMottakTjenesteTest {
+
+    private static final String INNMELDER_UID = "12324312345";
+
+    @Mock
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+    @Mock
+    private InntektsmeldingRepository inntektsmeldingRepository;
+    @Mock
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+
+    private InntektsmeldingMottakTjeneste inntektsmeldingMottakTjeneste;
+
+    @BeforeAll
+    static void beforeAll() {
+        KontekstHolder.setKontekst(RequestKontekst.forRequest(INNMELDER_UID, "kompakt", IdentType.EksternBruker,
+            new OpenIDToken(OpenIDProvider.TOKENX, new TokenString("token")), UUID.randomUUID(), Set.of()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        KontekstHolder.fjernKontekst();
+    }
+
+    @BeforeEach
+    void setUp() {
+        inntektsmeldingMottakTjeneste = new InntektsmeldingMottakTjeneste(forespørselBehandlingTjeneste, inntektsmeldingRepository, prosessTaskTjeneste);
+    }
+
+
+    @Test
+    void skal_ikke_godta_im_på_utgått_forespørrsel() {
+        // Arrange
+        var uuid = UUID.randomUUID();
+        var forespørsel = ForespørselMapper.mapForespørsel("999999999",
+            LocalDate.now(),
+            "9999999999999",
+            Ytelsetype.PLEIEPENGER_SYKT_BARN,
+            "123",
+            null,
+            null);
+        forespørsel.setStatus(ForespørselStatus.UTGÅTT);
+        when(forespørselBehandlingTjeneste.hentForespørsel(uuid)).thenReturn(Optional.of(forespørsel));
+        var innsendingDto = new SendInntektsmeldingRequestDto(uuid,
+            new AktørIdDto("9999999999999"),
+            YtelseTypeDto.PLEIEPENGER_SYKT_BARN,
+            new ArbeidsgiverDto("999999999"),
+            new SendInntektsmeldingRequestDto.KontaktpersonRequestDto("Navn", "123"),
+            LocalDate.now(),
+            BigDecimal.valueOf(10000),
+            List.of(),
+            List.of(),
+            List.of(),
+            null);
+
+        // Act
+        var ex = assertThrows(IllegalStateException.class, () -> inntektsmeldingMottakTjeneste.mottaInntektsmelding(innsendingDto));
+
+        // Assert
+        assertThat(ex.getMessage()).contains("Kan ikke motta nye inntektsmeldinger på utgåtte forespørsler");
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
@@ -114,7 +114,7 @@ class InntektsmeldingTjenesteTest {
             List.of(inntekt1, inntekt2, inntekt3)));
 
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.lagDialogDto(uuid);
+        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(uuid);
 
         // Assert
         assertThat(imDialogDto.skjæringstidspunkt()).isEqualTo(forespørsel.getSkjæringstidspunkt());
@@ -180,7 +180,7 @@ class InntektsmeldingTjenesteTest {
             List.of()));
 
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.lagDialogDto(uuid);
+        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(uuid);
 
         // Assert
         assertThat(imDialogDto.skjæringstidspunkt()).isEqualTo(forespørsel.getSkjæringstidspunkt());
@@ -252,7 +252,7 @@ class InntektsmeldingTjenesteTest {
             LocalDate.now(),
             organisasjonsnummer.orgnr())).thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.lagArbeidsgiverinitiertDialogDto(fødselsnummer,
+        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(fødselsnummer,
             ytelsetype,
             førsteFraværsdag,
             organisasjonsnummer);
@@ -291,7 +291,7 @@ class InntektsmeldingTjenesteTest {
             LocalDate.now(),
             organisasjonsnummer.orgnr())).thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.lagArbeidsgiverinitiertDialogDto(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer);
+        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer);
 
         // Assert
         assertThat(imDialogDto.person().aktørId()).isEqualTo(aktørId.getAktørId());

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjenesteTest.java
@@ -22,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselMapper;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
-import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingDialogDto;
 import no.nav.familie.inntektsmelding.integrasjoner.dokgen.K9DokgenTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
@@ -34,6 +33,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.ArbeidsforholdDto;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.ArbeidstakerTjeneste;
+import no.nav.familie.inntektsmelding.typer.dto.MånedsinntektDto;
 import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
@@ -137,17 +137,17 @@ class InntektsmeldingTjenesteTest {
         assertThat(imDialogDto.inntektsopplysninger().månedsinntekter()).hasSize(3);
         assertThat(imDialogDto.inntektsopplysninger().gjennomsnittLønn()).isEqualByComparingTo(BigDecimal.valueOf(52_000));
         assertThat(imDialogDto.inntektsopplysninger().månedsinntekter()).contains(
-            new InntektsmeldingDialogDto.InntektsopplysningerDto.MånedsinntektDto(LocalDate.of(2024, 3, 1),
+            new MånedsinntektDto(LocalDate.of(2024, 3, 1),
                 LocalDate.of(2024, 3, 31),
                 BigDecimal.valueOf(52_000),
                 MånedslønnStatus.BRUKT_I_GJENNOMSNITT));
         assertThat(imDialogDto.inntektsopplysninger().månedsinntekter()).contains(
-            new InntektsmeldingDialogDto.InntektsopplysningerDto.MånedsinntektDto(LocalDate.of(2024, 4, 1),
+            new MånedsinntektDto(LocalDate.of(2024, 4, 1),
                 LocalDate.of(2024, 4, 30),
                 BigDecimal.valueOf(52_000),
                 MånedslønnStatus.BRUKT_I_GJENNOMSNITT));
         assertThat(imDialogDto.inntektsopplysninger().månedsinntekter()).contains(
-            new InntektsmeldingDialogDto.InntektsopplysningerDto.MånedsinntektDto(LocalDate.of(2024, 5, 1),
+            new MånedsinntektDto(LocalDate.of(2024, 5, 1),
                 LocalDate.of(2024, 5, 31),
                 BigDecimal.valueOf(52_000),
                 MånedslønnStatus.BRUKT_I_GJENNOMSNITT));


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi har behov for å refaktorere koden i InntektsmeldingTjenesten før vi begynner å utvide med ny funksjonalitet for å støtte arbeidsgiver initiert inntektsmelding.

### **Løsning**
- Trekker ut metoder for mottak av inntektsmelding fra InntektsmeldingTjeneste til ny InntektsmeldingMottatTjeneste
- Trekker ut dto-er i InntektsmeldingDialogDto til egne filer
- Renamer InntektsmeldingDialogDto –> HentOpplysningerResponse så det stemmer med metoden hentOpplysninger() i InntektsmeldingDialogRest