### PR TITLE
TSFF-1932: Hent opplysninger for arbeidsgiverinitiert inntektsmelding for nyansatt

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -67,7 +67,7 @@ public class ArbeidsgiverinitiertDialogRest {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
         LOG.info("Henter opplysninger for søker");
-        var hentOpplysningerResponse = grunnlagTjeneste.hentOpplysninger(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag(), request.organisasjonsnummer());
+        var hentOpplysningerResponse = grunnlagTjeneste.hentOpplysningerForNyansatt(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag(), request.organisasjonsnummer());
         return Response.ok(hentOpplysningerResponse).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -60,15 +60,12 @@ public class GrunnlagTjeneste {
 
     public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
         var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
-            .orElseThrow(() -> new IllegalStateException(
-                "Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
+            .orElseThrow(() -> new IllegalStateException("Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
+
         var personInfo = finnPerson(forespørsel.getAktørId());
         var organisasjonInfo = finnOrganisasjonInfo(forespørsel.getOrganisasjonsnummer());
         var innsender = finnInnsender();
-        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getUuid(),
-            forespørsel.getAktørId(),
-            forespørsel.getSkjæringstidspunkt(),
-            forespørsel.getOrganisasjonsnummer());
+        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getUuid(), forespørsel.getAktørId(), forespørsel.getSkjæringstidspunkt(), forespørsel.getOrganisasjonsnummer());
 
         return new HentOpplysningerResponse(personInfo,
             organisasjonInfo,
@@ -122,23 +119,25 @@ public class GrunnlagTjeneste {
         if (!KontekstHolder.harKontekst() || !IdentType.EksternBruker.equals(KontekstHolder.getKontekst().getIdentType())) {
             throw new IllegalStateException("Mangler innlogget bruker kontekst.");
         }
+
         var pid = KontekstHolder.getKontekst().getUid();
         var personInfo = personTjeneste.hentPersonFraIdent(PersonIdent.fra(pid));
-        return new InnsenderDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(),
-            personInfo.telefonnummer());
+
+        return new InnsenderDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(), personInfo.telefonnummer());
     }
 
     private InntektsopplysningerDto finnInntektsopplysninger(UUID uuid,
                                                              AktørIdEntitet aktørId,
                                                              LocalDate skjæringstidspunkt,
                                                              String organisasjonsnummer) {
-        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(),
-            organisasjonsnummer);
+        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(), organisasjonsnummer);
+
         if (uuid == null) {
             LOG.info("Inntektsopplysninger for aktørId {} var {}", aktørId, inntektsopplysninger);
         } else {
             LOG.info("Inntektsopplysninger for forespørsel {} var {}", uuid, inntektsopplysninger);
         }
+
         var inntekter = inntektsopplysninger.måneder()
             .stream()
             .map(i -> new MånedsinntektDto(i.månedÅr().atDay(1),
@@ -146,6 +145,7 @@ public class GrunnlagTjeneste {
                 i.beløp(),
                 i.status()))
             .toList();
+
         return new InntektsopplysningerDto(inntektsopplysninger.gjennomsnitt(), inntekter);
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -60,15 +60,12 @@ public class GrunnlagTjeneste {
 
     public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
         var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
-            .orElseThrow(() -> new IllegalStateException(
-                "Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
+            .orElseThrow(() -> new IllegalStateException("Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
+
         var personInfo = finnPerson(forespørsel.getAktørId());
         var organisasjonInfo = finnOrganisasjonInfo(forespørsel.getOrganisasjonsnummer());
         var innsender = finnInnsender();
-        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getUuid(),
-            forespørsel.getAktørId(),
-            forespørsel.getSkjæringstidspunkt(),
-            forespørsel.getOrganisasjonsnummer());
+        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getAktørId(), forespørsel.getSkjæringstidspunkt(), forespørsel.getOrganisasjonsnummer());
 
         return new HentOpplysningerResponse(personInfo,
             organisasjonInfo,
@@ -103,7 +100,7 @@ public class GrunnlagTjeneste {
 
         var organisasjonInfo = finnOrganisasjonInfo(organisasjonsnummer.orgnr());
         var innsender = finnInnsender();
-        var inntektsopplysninger = finnInntektsopplysninger(null, personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr());
+        var inntektsopplysninger = finnInntektsopplysninger(personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr());
 
         return new HentOpplysningerResponse(lagPersonInfoDto(personInfo),
             organisasjonInfo,
@@ -128,19 +125,12 @@ public class GrunnlagTjeneste {
             personInfo.telefonnummer());
     }
 
-    private InntektsopplysningerDto finnInntektsopplysninger(UUID uuid,
-                                                             AktørIdEntitet aktørId,
+    private InntektsopplysningerDto finnInntektsopplysninger(AktørIdEntitet aktørId,
                                                              LocalDate skjæringstidspunkt,
                                                              String organisasjonsnummer) {
-        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(),
-            organisasjonsnummer);
-        if (uuid == null) {
-            LOG.info("Inntektsopplysninger for aktørId {} var {}", aktørId, inntektsopplysninger);
-        } else {
-            LOG.info("Inntektsopplysninger for forespørsel {} var {}", uuid, inntektsopplysninger);
-        }
-        var inntekter = inntektsopplysninger.måneder()
-            .stream()
+        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(), organisasjonsnummer);
+
+        var inntekter = inntektsopplysninger.måneder().stream()
             .map(i -> new MånedsinntektDto(i.månedÅr().atDay(1),
                 i.månedÅr().atEndOfMonth(),
                 i.beløp(),

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -60,12 +60,15 @@ public class GrunnlagTjeneste {
 
     public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
         var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
-            .orElseThrow(() -> new IllegalStateException("Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
-
+            .orElseThrow(() -> new IllegalStateException(
+                "Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
         var personInfo = finnPerson(forespørsel.getAktørId());
         var organisasjonInfo = finnOrganisasjonInfo(forespørsel.getOrganisasjonsnummer());
         var innsender = finnInnsender();
-        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getAktørId(), forespørsel.getSkjæringstidspunkt(), forespørsel.getOrganisasjonsnummer());
+        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getUuid(),
+            forespørsel.getAktørId(),
+            forespørsel.getSkjæringstidspunkt(),
+            forespørsel.getOrganisasjonsnummer());
 
         return new HentOpplysningerResponse(personInfo,
             organisasjonInfo,
@@ -100,7 +103,7 @@ public class GrunnlagTjeneste {
 
         var organisasjonInfo = finnOrganisasjonInfo(organisasjonsnummer.orgnr());
         var innsender = finnInnsender();
-        var inntektsopplysninger = finnInntektsopplysninger(personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr());
+        var inntektsopplysninger = finnInntektsopplysninger(null, personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr());
 
         return new HentOpplysningerResponse(lagPersonInfoDto(personInfo),
             organisasjonInfo,
@@ -125,12 +128,19 @@ public class GrunnlagTjeneste {
             personInfo.telefonnummer());
     }
 
-    private InntektsopplysningerDto finnInntektsopplysninger(AktørIdEntitet aktørId,
+    private InntektsopplysningerDto finnInntektsopplysninger(UUID uuid,
+                                                             AktørIdEntitet aktørId,
                                                              LocalDate skjæringstidspunkt,
                                                              String organisasjonsnummer) {
-        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(), organisasjonsnummer);
-
-        var inntekter = inntektsopplysninger.måneder().stream()
+        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(),
+            organisasjonsnummer);
+        if (uuid == null) {
+            LOG.info("Inntektsopplysninger for aktørId {} var {}", aktørId, inntektsopplysninger);
+        } else {
+            LOG.info("Inntektsopplysninger for forespørsel {} var {}", uuid, inntektsopplysninger);
+        }
+        var inntekter = inntektsopplysninger.måneder()
+            .stream()
             .map(i -> new MånedsinntektDto(i.månedÅr().atDay(1),
                 i.månedÅr().atEndOfMonth(),
                 i.beløp(),

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -245,7 +245,7 @@ class GrunnlagTjenesteTest {
             LocalDate.now(),
             organisasjonsnummer.orgnr())).thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
         // Act
-        var imDialogDto = grunnlagTjeneste.hentOpplysninger(fødselsnummer,
+        var imDialogDto = grunnlagTjeneste.hentOpplysningerForNyansatt(fødselsnummer,
             ytelsetype,
             førsteFraværsdag,
             organisasjonsnummer);
@@ -284,7 +284,7 @@ class GrunnlagTjenesteTest {
             LocalDate.now(),
             organisasjonsnummer.orgnr())).thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
         // Act
-        var imDialogDto = grunnlagTjeneste.hentOpplysninger(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer);
+        var imDialogDto = grunnlagTjeneste.hentOpplysningerForNyansatt(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer);
 
         // Assert
         assertThat(imDialogDto.person().aktørId()).isEqualTo(aktørId.getAktørId());


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dersom en bruker bytter jobb samtidig som de mottar en ytelse, vil ikke k9-sak utlede at det mangler en inntektsmelding. Det vil derfor ikke bli opprettet en forespørsel for den nye arbeidsgiveren dersom de ønsker å refundere. 

For å støtte at arbeidsgivere sende inne en inntektsmelding hvor de ber om refusjon for nyansatte, må vi hente opplysninger på en litt annen måte.

Jira: https://jira.adeo.no/browse/TSFF-1932

### **Løsning**
- Mye av funksjonaliteten er allerede på plass fra da vi delte kodebase med foreldrepenger. 
- Legger til forklarende kommentarer