### PR TITLE
TSFF-1746: Sjekk om det finnes sak i k9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
         <felles.version>7.5.10</felles.version>
         <prosesstask.version>5.1.11</prosesstask.version>
         <fp-kontrakter.version>9.3.8</fp-kontrakter.version>
+
+        <k9-sak.version>5.4.25</k9-sak.version>
     </properties>
 
     <dependencyManagement>
@@ -64,6 +66,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>no.nav.k9.sak</groupId>
+                <artifactId>kontrakt</artifactId>
+                <version>${k9-sak.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -104,7 +111,10 @@
             <groupId>no.nav.foreldrepenger.kontrakter</groupId>
             <artifactId>inntektsmelding-v1</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>no.nav.k9.sak</groupId>
+            <artifactId>kontrakt</artifactId>
+        </dependency>
 
         <!-- CDI -->
         <dependency>

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -1,5 +1,7 @@
 package no.nav.familie.inntektsmelding.imdialog.rest;
 
+import java.util.List;
+
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -16,9 +18,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.imdialog.tjenester.GrunnlagTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.K9SakTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedTokenX;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.exception.FunksjonellException;
 
 @AutentisertMedTokenX
 @RequestScoped
@@ -33,6 +40,8 @@ public class ArbeidsgiverinitiertDialogRest {
     private static final String HENT_OPPLYSNINGER = "/opplysninger";
 
     private GrunnlagTjeneste grunnlagTjeneste;
+    private PersonTjeneste personTjeneste;
+    private K9SakTjeneste k9SakTjeneste;
     private boolean erProd = true;
 
     ArbeidsgiverinitiertDialogRest() {
@@ -40,8 +49,10 @@ public class ArbeidsgiverinitiertDialogRest {
     }
 
     @Inject
-    public ArbeidsgiverinitiertDialogRest(GrunnlagTjeneste grunnlagTjeneste) {
+    public ArbeidsgiverinitiertDialogRest(GrunnlagTjeneste grunnlagTjeneste, PersonTjeneste personTjeneste, K9SakTjeneste k9SakTjeneste) {
         this.grunnlagTjeneste = grunnlagTjeneste;
+        this.personTjeneste = personTjeneste;
+        this.k9SakTjeneste = k9SakTjeneste;
         this.erProd = Environment.current().isProd();
     }
 
@@ -54,6 +65,21 @@ public class ArbeidsgiverinitiertDialogRest {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
         LOG.info("Henter arbeidsforhold for søker");
+
+        // Sjekk at person finnes
+        PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
+        if (personInfo == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        // Sjekk at søker har sak i k9-sak
+        List<FagsakInfo> fagsakerIK9Sak =  k9SakTjeneste.hentFagsakInfo(request.ytelseType(), request.fødselsnummer());
+        var finnesSakIK9 = fagsakerIK9Sak.stream().anyMatch(fagsak -> fagsak.gyldigPeriode().inneholderDato(request.førsteFraværsdag()));
+        if (!finnesSakIK9) {
+            var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen", request.ytelseType());
+            throw new FunksjonellException("INGEN_SAK_FUNNET", feilmelding, null, null);
+        }
+
         var response = grunnlagTjeneste.finnArbeidsforholdForFnr(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag());
         return response.map(d ->Response.ok(d).build()).orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
@@ -1,0 +1,10 @@
+package no.nav.familie.inntektsmelding.integrasjoner.k9sak;
+
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
+
+public record FagsakInfo(SaksnummerDto saksnummer,
+                         Ytelsetype ytelseType,
+                         PeriodeDto gyldigPeriode) {
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
@@ -1,0 +1,68 @@
+package no.nav.familie.inntektsmelding.integrasjoner.k9sak;
+
+import java.net.URI;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.k9.kodeverk.behandling.FagsakYtelseType;
+import no.nav.k9.sak.kontrakt.fagsak.FagsakInfoDto;
+import no.nav.k9.sak.kontrakt.fagsak.MatchFagsak;
+import no.nav.k9.sak.typer.Periode;
+import no.nav.k9.sak.typer.PersonIdent;
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
+
+@ApplicationScoped
+@RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, scopesProperty = "k9sak.scopes", scopesDefault = "api://prod-fss.k9saksbehandling.k9-sak/.default", endpointDefault = "http://k9-sak", endpointProperty = "k9sak.url")
+public class K9SakKlient {
+    private static final String K9SAK_FAKSAKINFO_PATH = "/k9/sak/api/fagsak/match";
+    private static final Logger LOG = LoggerFactory.getLogger(K9SakKlient.class);
+
+    private RestClient restClient;
+    private RestConfig restConfig;
+
+    public K9SakKlient() {
+        // CDI
+    }
+
+    public K9SakKlient(RestClient restClient, RestConfig restConfig) {
+        this.restClient = restClient;
+        this.restConfig = RestConfig.forClient(this.getClass());
+    }
+
+    public List<FagsakInfoDto> hentFagsakInfo(Ytelsetype ytelsetype, String personIdent) {
+        URI url = UriBuilder.fromUri(restConfig.endpoint()).path(K9SAK_FAKSAKINFO_PATH).build();
+        Periode gyldigPeriode = null; // setter null for å sjekke alle perioder
+        PersonIdent bruker = new PersonIdent(personIdent);
+        List<PersonIdent> pleietrengende = null; // søker uten pleietrengende
+        List<PersonIdent> annenPart = null; // søker uten annen part
+
+        var requestDto = new MatchFagsak(mapYtelsetype(ytelsetype), gyldigPeriode, bruker, pleietrengende, annenPart);
+        var request = RestRequest.newPOSTJson(requestDto, url, restConfig);
+
+        try {
+            return restClient.sendReturnList(request, FagsakInfoDto.class);
+        } catch (Exception e) {
+            LOG.error("Kall mot k9-sak feilet for personIdent {}", personIdent, e);
+            throw new RuntimeException("Kall mot k9-sak feilet", e);
+        }
+    }
+
+    private FagsakYtelseType mapYtelsetype(Ytelsetype ytelsetype) {
+        return switch (ytelsetype) {
+            case PLEIEPENGER_SYKT_BARN -> FagsakYtelseType.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_NÆRSTÅENDE -> FagsakYtelseType.PLEIEPENGER_NÆRSTÅENDE;
+            case OMSORGSPENGER -> FagsakYtelseType.OMSORGSPENGER;
+            case OPPLÆRINGSPENGER -> FagsakYtelseType.OPPLÆRINGSPENGER;
+        };
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
@@ -22,9 +22,9 @@ import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 
 @ApplicationScoped
-@RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, scopesProperty = "k9sak.scopes", scopesDefault = "api://prod-fss.k9saksbehandling.k9-sak/.default", endpointDefault = "http://k9-sak", endpointProperty = "k9sak.url")
+@RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, scopesProperty = "k9sak.scopes", scopesDefault = "api://dev-fss.k9saksbehandling.k9-sak/.default", endpointDefault = "http://k9-sak", endpointProperty = "k9sak.url")
 public class K9SakKlient {
-    private static final String K9SAK_FAKSAKINFO_PATH = "/k9/sak/api/fagsak/match";
+    private static final String K9SAK_FAKSAKINFO_PATH = "/fagsak/match";
     private static final Logger LOG = LoggerFactory.getLogger(K9SakKlient.class);
 
     private RestClient restClient;

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
@@ -22,7 +22,7 @@ import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 
 @ApplicationScoped
-@RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, scopesProperty = "k9sak.scopes", scopesDefault = "api://dev-fss.k9saksbehandling.k9-sak/.default", endpointDefault = "http://k9-sak", endpointProperty = "k9sak.url")
+@RestClientConfig(tokenConfig = TokenFlow.AZUREAD_CC, scopesProperty = "k9sak.scopes", scopesDefault = "api://dev-fss.k9saksbehandling.k9-sak/.default", endpointDefault = "https://k9-sak.dev-fss-pub.nais.io/k9/sak/api", endpointProperty = "k9sak.url")
 public class K9SakKlient {
     private static final String K9SAK_FAKSAKINFO_PATH = "/fagsak/match";
     private static final Logger LOG = LoggerFactory.getLogger(K9SakKlient.class);

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
@@ -1,0 +1,49 @@
+package no.nav.familie.inntektsmelding.integrasjoner.k9sak;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
+import no.nav.k9.kodeverk.behandling.FagsakYtelseType;
+import no.nav.k9.sak.kontrakt.fagsak.FagsakInfoDto;
+
+@ApplicationScoped
+public class K9SakTjeneste {
+    private K9SakKlient klient;
+
+    public K9SakTjeneste() {
+        // CDI
+    }
+
+    public K9SakTjeneste(K9SakKlient klient) {
+        this.klient = klient;
+    }
+
+    public List<FagsakInfo> hentFagsakInfo(Ytelsetype ytelsetype, PersonIdent personIdent) {
+        List<FagsakInfoDto> k9Fagsaker = klient.hentFagsakInfo(ytelsetype, personIdent.getIdent());
+
+        return k9Fagsaker.stream()
+            .map(k9Fagsak ->
+                new FagsakInfo(
+                    new SaksnummerDto(k9Fagsak.getSaksnummer().getVerdi()),
+                    mapYtelsetype(k9Fagsak.getYtelseType()),
+                    new PeriodeDto(k9Fagsak.getGyldigPeriode().getFom(), k9Fagsak.getGyldigPeriode().getTom())
+                )
+            ).toList();
+    }
+
+    private Ytelsetype mapYtelsetype(FagsakYtelseType fagsagYtelseType) {
+        return switch (fagsagYtelseType) {
+            case PLEIEPENGER_SYKT_BARN -> Ytelsetype.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_NÆRSTÅENDE -> Ytelsetype.PLEIEPENGER_NÆRSTÅENDE;
+            case OMSORGSPENGER -> Ytelsetype.OMSORGSPENGER;
+            case OPPLÆRINGSPENGER -> Ytelsetype.OPPLÆRINGSPENGER;
+            default -> throw new IllegalArgumentException("Ukjent ytelsetype: " + fagsagYtelseType);
+        };
+    }
+
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/PeriodeDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/PeriodeDto.java
@@ -12,4 +12,8 @@ public record PeriodeDto(@NotNull LocalDate fom,
     private boolean isValid() {
         return fom.isBefore(tom) || fom.isEqual(tom);
     }
+
+    public boolean inneholderDato(LocalDate dato) {
+        return (dato.isEqual(fom) || dato.isAfter(fom)) && (dato.isEqual(tom) || dato.isBefore(tom));
+    }
 }

--- a/src/main/resources/application-dev-gcp.properties
+++ b/src/main/resources/application-dev-gcp.properties
@@ -17,7 +17,7 @@ altinn.scopes=api://dev-gcp.arbeidsgiver.altinn-rettigheter-proxy/.default
 dokarkiv.base.url=https://dokarkiv-q2.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost
 dokarkiv.scopes=api://dev-fss.teamdokumenthandtering.dokarkiv/.default
 
-k9sak.url=http://k9-sak.k9saksbehandling/k9/sak/api
+k9sak.url=https://k9-sak.dev-fss-pub.nais.io/k9/sak/api
 k9sak.scopes=api://dev-fss.k9saksbehandling.k9-sak/.default
 
 k9dokgen.url=http://k9-dokgen

--- a/src/main/resources/application-dev-gcp.properties
+++ b/src/main/resources/application-dev-gcp.properties
@@ -17,6 +17,9 @@ altinn.scopes=api://dev-gcp.arbeidsgiver.altinn-rettigheter-proxy/.default
 dokarkiv.base.url=https://dokarkiv-q2.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost
 dokarkiv.scopes=api://dev-fss.teamdokumenthandtering.dokarkiv/.default
 
+k9sak.url=http://k9-sak.k9saksbehandling/k9/sak/api
+k9sak.scopes=api://dev-fss.k9saksbehandling.k9-sak/.default
+
 k9dokgen.url=http://k9-dokgen
 
 paaminnelse.etter.dager=1

--- a/src/main/resources/application-prod-gcp.properties
+++ b/src/main/resources/application-prod-gcp.properties
@@ -14,6 +14,9 @@ organisasjon.rs.url=https://ereg-services.prod-fss-pub.nais.io/api/v2/organisasj
 
 altinn.scopes=api://prod-gcp.arbeidsgiver.altinn-rettigheter-proxy/.default
 
+k9sak.url=http://k9-sak.k9saksbehandling/k9/sak/api
+k9sak.scopes=api://prod-fss.k9saksbehandling.k9-sak/.default
+
 k9dokgen.url=http://k9-dokgen
 
 dokarkiv.base.url=https://dokarkiv.prod-fss-pub.nais.io/rest/journalpostapi/v1/journalpost

--- a/src/main/resources/application-prod-gcp.properties
+++ b/src/main/resources/application-prod-gcp.properties
@@ -14,7 +14,7 @@ organisasjon.rs.url=https://ereg-services.prod-fss-pub.nais.io/api/v2/organisasj
 
 altinn.scopes=api://prod-gcp.arbeidsgiver.altinn-rettigheter-proxy/.default
 
-k9sak.url=http://k9-sak.k9saksbehandling/k9/sak/api
+k9sak.url=https://k9-sak.prod-fss-pub.nais.io/k9/sak/api
 k9sak.scopes=api://prod-fss.k9saksbehandling.k9-sak/.default
 
 k9dokgen.url=http://k9-dokgen


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dersom man forsøker å sende inne en inntektsmelding på en person og vi ikke finner en sak på i k9, skal ikke arbeidsgiver få lov til å sende inn. Feilmelding til arbeidsgiver i disse tilfellene: "Du kan ikke sende inn inntektsmelding på {ytelsetype} på denne personen".

Jira: https://jira.adeo.no/browse/TSFF-1746

### **Løsning**
- Ny integrasjon til k9-sak: K9SakKlient
- Henter saker i k9 i endepunktet som henter arbeidsforhold: `/arbeidsforhold`.

### **Andre endringer**
Importerer kontraktene til k9-sak. På sikt burde vi legge request- og respons-objektene som endepunktene for opprettelse, henting, osv... av forespørsler bruker i dag.
