### PR TITLE
TSFF-1746: Hent søknadsperiodene fra brukers saker i k9 og sjekk om stp treffer en søknadsperidoe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <prosesstask.version>5.1.11</prosesstask.version>
         <fp-kontrakter.version>9.3.8</fp-kontrakter.version>
 
-        <k9-sak.version>5.4.25</k9-sak.version>
+        <k9-sak.version>6.0.0</k9-sak.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -24,6 +24,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedTokenX;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.exception.FunksjonellException;
 
@@ -74,7 +75,13 @@ public class ArbeidsgiverinitiertDialogRest {
 
         // Sjekk at søker har sak i k9-sak
         List<FagsakInfo> fagsakerIK9Sak =  k9SakTjeneste.hentFagsakInfo(request.ytelseType(), request.fødselsnummer());
-        var finnesSakIK9 = fagsakerIK9Sak.stream().anyMatch(fagsak -> fagsak.gyldigPeriode().inneholderDato(request.førsteFraværsdag()));
+        List<PeriodeDto> søknadsPerioderForFagsakerIK9 = fagsakerIK9Sak.stream()
+            .flatMap(fagsak -> fagsak.søknadsPerioder().stream())
+            .toList();
+
+        var finnesSakIK9 = søknadsPerioderForFagsakerIK9.stream()
+            .anyMatch(søknandsperiode -> søknandsperiode.inneholderDato(request.førsteFraværsdag()));
+
         if (!finnesSakIK9) {
             var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen", request.ytelseType());
             throw new FunksjonellException("INGEN_SAK_FUNNET", feilmelding, null, null);

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
@@ -1,10 +1,13 @@
 package no.nav.familie.inntektsmelding.integrasjoner.k9sak;
 
+import java.util.List;
+
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 
 public record FagsakInfo(SaksnummerDto saksnummer,
                          Ytelsetype ytelseType,
-                         PeriodeDto gyldigPeriode) {
+                         PeriodeDto gyldigPeriode,
+                         List<PeriodeDto> søknadsPerioder) {
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakKlient.java
@@ -3,12 +3,13 @@ package no.nav.familie.inntektsmelding.integrasjoner.k9sak;
 import java.net.URI;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.UriBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.k9.kodeverk.behandling.FagsakYtelseType;
 import no.nav.k9.sak.kontrakt.fagsak.FagsakInfoDto;

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
@@ -33,9 +33,17 @@ public class K9SakTjeneste {
                 new FagsakInfo(
                     new SaksnummerDto(k9Fagsak.getSaksnummer().getVerdi()),
                     mapYtelsetype(k9Fagsak.getYtelseType()),
-                    new PeriodeDto(k9Fagsak.getGyldigPeriode().getFom(), k9Fagsak.getGyldigPeriode().getTom())
+                    new PeriodeDto(k9Fagsak.getGyldigPeriode().getFom(), k9Fagsak.getGyldigPeriode().getTom()),
+                    mapSøknadsperiode(k9Fagsak)
                 )
             ).toList();
+    }
+
+    private static List<PeriodeDto> mapSøknadsperiode(FagsakInfoDto k9Fagsak) {
+        return k9Fagsak.getSøknadsperioder()
+            .stream()
+            .map(søknadsPeriode -> new PeriodeDto(søknadsPeriode.getFom(), søknadsPeriode.getTom()))
+            .toList();
     }
 
     private Ytelsetype mapYtelsetype(FagsakYtelseType fagsagYtelseType) {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker ikke å sende inn inntektsmeldinger som ikke treffer en søknadsperiode. Tidligere sjekket vi mot `gyldigPeriode`, men det kan være opphold innenfor den gyldige perioden som vi ikke ønsker å få med. 

K9-sak har nå utvidet responsen slik at vi kan sjekke mot søknadsperiode. https://github.com/navikt/k9-sak/pull/12124

Jira: https://github.com/navikt/k9-sak/pull/12124

### **Løsning**
- Bumper k9-kontrakt for å få med søknadsperiodene. 
- sjekker om stp fra inntektsmeldingen treffer en av søknadsperiodene