### PR TITLE
TSFF-2020: Nytt forvaltningsendepunkt for å hente anatall rader i inntektsmeldingtabellen

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
@@ -1,8 +1,6 @@
 package no.nav.familie.inntektsmelding.imdialog.modell;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
@@ -45,5 +43,10 @@ public class InntektsmeldingRepository {
             .setParameter("år", år);
 
         return query.getResultList();
+    }
+
+    public long tellAntallInntektsmeldinger() {
+        var query = entityManager.createQuery("SELECT COUNT(i) FROM InntektsmeldingEntitet i", Long.class);
+        return query.getSingleResult();
     }
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker å utvide InntektsmeldingEntitet med nytt felt: InntektsmeldingType. Vi må derfor lage et migreringsscript og trenger oversikt over hvor mange rader som blir berørt for å ikke ta ned applikasjonen under migreringen.

Jira: https://jira.adeo.no/browse/TSFF-2020

### **Løsning**
Lager nytt forvaltningsendepunkt som henter antall rader i INNTEKTSMELDING tabellen.