### PR TITLE
TSFF-2020: Utvid inntektsmeldingtabellen med ny kolonne for InntektsmeldingType

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingEntitet.java
@@ -25,6 +25,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.Kildesystem;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
@@ -73,6 +74,10 @@ public class InntektsmeldingEntitet {
     @Enumerated(EnumType.STRING)
     @Column(name = "kildesystem", nullable = false, updatable = false)
     private Kildesystem kildesystem;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inntektsmelding_type", nullable = false)
+    private InntektsmeldingType inntektsmeldingType;
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "inntektsmelding")
     private List<RefusjonsendringEntitet> refusjonsendringer = new ArrayList<>();
@@ -150,6 +155,10 @@ public class InntektsmeldingEntitet {
         return kildesystem;
     }
 
+    public InntektsmeldingType getInntektsmeldingType() {
+        return inntektsmeldingType;
+    }
+
     public List<EndringsårsakEntitet> getEndringsårsaker() {
         return List.copyOf(endringsårsaker);
     }
@@ -197,12 +206,13 @@ public class InntektsmeldingEntitet {
             && Objects.equals(arbeidsgiverIdent, entitet.arbeidsgiverIdent)
             && Objects.equals(startDato, entitet.startDato)
             && Objects.equals(opprettetTidspunkt, entitet.opprettetTidspunkt)
-            && Objects.equals(forespørsel, entitet.forespørsel);
+            && Objects.equals(forespørsel, entitet.forespørsel)
+            && Objects.equals(inntektsmeldingType, entitet.inntektsmeldingType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(aktørId, ytelsetype, arbeidsgiverIdent, startDato, opprettetTidspunkt, forespørsel);
+        return Objects.hash(aktørId, ytelsetype, arbeidsgiverIdent, startDato, opprettetTidspunkt, forespørsel, inntektsmeldingType);
     }
 
     @Override
@@ -219,7 +229,9 @@ public class InntektsmeldingEntitet {
             + ", endringAvInntektÅrsaker=" + endringsårsaker
             + ", bortfaltNaturalYtelser=" + borfalteNaturalYtelser
             + ", omorgspenger=" + omsorgspenger
-            + ", forespørselId=" + forespørsel + '}';
+            + ", forespørselId=" + forespørsel
+            + ", inntektsmeldingType=" + inntektsmeldingType
+            + '}';
     }
 
     private String maskerId(String id) {
@@ -309,6 +321,11 @@ public class InntektsmeldingEntitet {
 
         public Builder medKildesystem(Kildesystem kildesystem) {
             kladd.kildesystem = kildesystem;
+            return this;
+        }
+
+        public Builder medInntektsmeldingType(InntektsmeldingType inntektsmeldingType) {
+            kladd.inntektsmeldingType = inntektsmeldingType;
             return this;
         }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapper.java
@@ -23,6 +23,7 @@ import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingResponseDto;
 import no.nav.familie.inntektsmelding.imdialog.rest.OmsorgspengerRequestDto;
 import no.nav.familie.inntektsmelding.imdialog.rest.SendInntektsmeldingForArbeidsgiverinitiertNyansattRequest;
 import no.nav.familie.inntektsmelding.imdialog.rest.SendInntektsmeldingRequest;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.Kildesystem;
 import no.nav.familie.inntektsmelding.typer.dto.AktørIdDto;
 import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
@@ -52,6 +53,7 @@ public class InntektsmeldingMapper {
             .medArbeidsgiverIdent(request.arbeidsgiverIdent().ident())
             .medMånedInntekt(request.inntekt())
             .medKildesystem(Kildesystem.ARBEIDSGIVERPORTAL)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedRefusjon(refusjonPrMnd)
             .medRefusjonOpphørsdato(opphørsdato)
             .medStartDato(request.startdato())
@@ -73,7 +75,7 @@ public class InntektsmeldingMapper {
         return inntektsmeldingBuilder.build();
     }
 
-    public static InntektsmeldingEntitet mapTilEntitet(SendInntektsmeldingForArbeidsgiverinitiertNyansattRequest request, ForespørselEntitet forespørsel) {
+    public static InntektsmeldingEntitet mapTilEntitetForAGNyansatt(SendInntektsmeldingForArbeidsgiverinitiertNyansattRequest request, ForespørselEntitet forespørsel) {
         // Frontend sender kun inn liste med refusjon. Vi utleder startsum og opphørsdato utifra denne lista.
         var refusjonPrMnd = finnFørsteRefusjon(request.refusjon(), request.startdato()).orElse(null);
         var opphørsdato = refusjonPrMnd == null ? null : finnOpphørsdato(request.refusjon(), request.startdato()).orElse(Tid.TIDENES_ENDE);
@@ -84,6 +86,7 @@ public class InntektsmeldingMapper {
             .medArbeidsgiverIdent(request.arbeidsgiverIdent().ident())
             .medMånedInntekt(refusjonPrMnd)
             .medKildesystem(Kildesystem.ARBEIDSGIVERPORTAL)
+            .medInntektsmeldingType(InntektsmeldingType.ARBEIDSGIVERINITIERT_NYANSATT)
             .medMånedRefusjon(refusjonPrMnd)
             .medRefusjonOpphørsdato(opphørsdato)
             .medStartDato(request.startdato())

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
@@ -127,7 +127,7 @@ public class InntektsmeldingMottakTjeneste {
         var forespørselEnitet = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
             .orElseThrow(this::manglerForespørselFeil);
 
-        var inntektsmeldingEntitet = InntektsmeldingMapper.mapTilEntitet(sendInntektsmeldingForArbeidsgiverinitiertNyansattRequest, forespørselEnitet);
+        var inntektsmeldingEntitet = InntektsmeldingMapper.mapTilEntitetForAGNyansatt(sendInntektsmeldingForArbeidsgiverinitiertNyansattRequest, forespørselEnitet);
         var inntektsmeldingId = lagreOgLagJournalførTask(inntektsmeldingEntitet, forespørselEnitet);
 
         forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid, aktørId, organisasjonsnummer, LukkeÅrsak.ORDINÆR_INNSENDING);

--- a/src/main/java/no/nav/familie/inntektsmelding/koder/InntektsmeldingType.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/koder/InntektsmeldingType.java
@@ -1,0 +1,8 @@
+package no.nav.familie.inntektsmelding.koder;
+
+public enum InntektsmeldingType {
+    ORDINÆR,
+    OMSORGSPENGER_REFUSJON,
+    ARBEIDSGIVERINITIERT_NYANSATT,
+    ARBEIDSGIVERINITIERT_UREGISTRERT
+}

--- a/src/main/resources/db/postgres/defaultDS/V1.0_026__add_inntektsmelding_type_column.sql
+++ b/src/main/resources/db/postgres/defaultDS/V1.0_026__add_inntektsmelding_type_column.sql
@@ -1,0 +1,10 @@
+-- Add inntektsmelding_type column with default value 'ORDINÆR'
+ALTER TABLE INNTEKTSMELDING ADD COLUMN inntektsmelding_type VARCHAR(255) DEFAULT 'ORDINÆR';
+
+-- Make the column NOT NULL (all existing rows will already have 'ORDINÆR' due to default)
+ALTER TABLE INNTEKTSMELDING ALTER COLUMN inntektsmelding_type SET NOT NULL;
+
+-- Add index for query performance on inntektsmelding_type
+CREATE INDEX idx_inntektsmelding_type ON INNTEKTSMELDING(inntektsmelding_type);
+
+COMMENT ON COLUMN INNTEKTSMELDING.inntektsmelding_type IS 'Hva slags type inntektsmelding det er';


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi har behov for å vite hva slags type inntektsmelding vi oppretter av flere grunner: 
1. Etter at arbeidsgiver har sendt inn inntektsmeldingen skal de kunne endre den. Da burde de bli sendt inn til riktig frontend for den inntektsmelding typen.
2. K9-sak trenger å vite om inntektsmeldingen er arbeidsgiverinitiert. Hvis den er det, skal den ikke filtreres bort selv om første fraværsdag ikke er samme som skjæringstidspunktet i saken.
3. Lettere å utlede riktig pdf
4. Kan bli aktuelt for statistikk

Jira: https://jira.adeo.no/browse/TSFF-2020

### **Løsning**
- Oppretter InntektsmeldingType som kan være ORDINÆR, OMSORGSPENGER_REFUSJON, ARBEIDSGIVERINITIERT_NYANSATT, ARBEIDSGIVERINITIERT_UREGISTRERT
- Utvider InntektsmeldingEntitet med InntektsmeldingType
- Legger til migreringsscript som setter utvider INNTEKTSMELDING tabellen med InntektsmeldingType og setter default til ORDINÆR

### Til senere
Har opprettet ny oppgave for å sette InntektsmeldingType=OMSORGSPENGER_REFUSJON for de det gjelder: https://jira.adeo.no/browse/TSFF-2120