### PR TITLE
TSFF-2113: Send InntektsmeldingType som tilleggsopplysninger i journalposten

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/K9DokgenRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/K9DokgenRestTjeneste.java
@@ -37,6 +37,7 @@ import no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.RefusjonsendringEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.dokgen.K9DokgenTjeneste;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
@@ -96,6 +97,7 @@ public class K9DokgenRestTjeneste {
                 .medKontaktperson(new KontaktpersonEntitet(inntektsmeldingRequest.kontaktpersonNavn, inntektsmeldingRequest.kontaktpersonTlf))
                 .medMånedInntekt(inntektsmeldingRequest.maanedInntekt())
                 .medYtelsetype(mapYtelseType(inntektsmeldingRequest.ytelsetype()))
+                .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
                 .medOpprettetTidspunkt(LocalDateTime.now())
                 .medMånedRefusjon(inntektsmeldingRequest.maanedRefusjon())
                 .medStartDato(inntektsmeldingRequest.startdatoPermisjon())

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/task/SendTilJoarkTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/task/SendTilJoarkTask.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
 import no.nav.familie.inntektsmelding.imdialog.tjenester.InntektsmeldingTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.dokgen.K9DokgenTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.joark.JoarkTjeneste;
@@ -42,17 +43,17 @@ public class SendTilJoarkTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        var inntektsmeldingId = Integer.parseInt(prosessTaskData.getPropertyValue(KEY_INNTEKTSMELDING_ID));
-        var ytelseType = prosessTaskData.getPropertyValue(KEY_YTELSE_TYPE);
-        var fagsysteSaksnummer = prosessTaskData.getSaksnummer();
+        int inntektsmeldingId = Integer.parseInt(prosessTaskData.getPropertyValue(KEY_INNTEKTSMELDING_ID));
+        String ytelseType = prosessTaskData.getPropertyValue(KEY_YTELSE_TYPE);
+        String saksnummer = prosessTaskData.getSaksnummer();
 
-        LOG.info("Starter task for oversending til joark for ytelse {} saksnummer {}", ytelseType, fagsysteSaksnummer);
+        LOG.info("Starter task for oversending til joark for ytelse {} saksnummer {}", ytelseType, saksnummer);
 
-        var inntektsmelding = inntektsmeldingTjeneste.hentInntektsmelding(inntektsmeldingId);
-        var xml = inntektsmeldingXMLTjeneste.lagXMLAvInntektsmelding(inntektsmelding);
-        var pdf = k9DokgenTjeneste.mapDataOgGenererPdf(inntektsmelding);
+        InntektsmeldingEntitet inntektsmelding = inntektsmeldingTjeneste.hentInntektsmelding(inntektsmeldingId);
+        String xml = inntektsmeldingXMLTjeneste.lagXMLAvInntektsmelding(inntektsmelding);
+        byte[] pdf = k9DokgenTjeneste.mapDataOgGenererPdf(inntektsmelding);
 
-        joarkTjeneste.journalførInntektsmelding(xml, inntektsmelding, pdf, fagsysteSaksnummer);
+        joarkTjeneste.journalførInntektsmelding(xml, inntektsmelding, pdf, saksnummer);
         LOG.info("Sluttfører task oversendJoark");
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjeneste.java
@@ -24,6 +24,7 @@ import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.DokumentInfoOpprett;
 import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.Dokumentvariant;
 import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.OpprettJournalpostRequest;
 import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.Sak;
+import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.Tilleggsopplysning;
 
 @ApplicationScoped
 public class JoarkTjeneste {
@@ -36,6 +37,7 @@ public class JoarkTjeneste {
     // TODO Dette er brevkode for altinn skjema. Trenger vi egen?
     private static final String BREVKODE_IM = "4936";
     private static final String TEMA_K9 = "OMS";
+    private static final String INNTEKTSMELDING_TYPE = "inntektsmeldingType";
 
     private DokArkiv joarkKlient;
     private OrganisasjonTjeneste organisasjonTjeneste;
@@ -84,6 +86,7 @@ public class JoarkTjeneste {
             .medEksternReferanseId(UUID.randomUUID().toString())
             .medJournalfoerendeEnhet(JOURNALFØRENDE_ENHET)
             .medKanal(KANAL)
+            .medTilleggsopplysninger(List.of(new Tilleggsopplysning(INNTEKTSMELDING_TYPE, inntektsmeldingEntitet.getInntektsmeldingType().name())))
             .medDokumenter(lagDokumenter(xmlAvInntektsmelding, pdf));
 
         if (saksnummer != null) {

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/task/InntektsmeldingXMLMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/task/InntektsmeldingXMLMapperTest.java
@@ -9,17 +9,17 @@ import java.util.Map;
 
 import jakarta.xml.bind.JAXBElement;
 
-import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
-import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
-import no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet;
-import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
-import no.nav.familie.inntektsmelding.koder.Kildesystem;
-
 import org.junit.jupiter.api.Test;
 
 import no.nav.familie.inntektsmelding.imdialog.modell.BortaltNaturalytelseEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
+import no.nav.familie.inntektsmelding.koder.Kildesystem;
 import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
@@ -150,6 +150,7 @@ class InntektsmeldingXMLMapperTest {
             .medAktørId(aktørId)
             .medKildesystem(kildesystem)
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .build();
     }
 
@@ -162,6 +163,7 @@ class InntektsmeldingXMLMapperTest {
             .medKildesystem(kildesystem)
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
             .medOmsorgspenger(omsorgspenger)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .build();
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/task/InntektsmeldingXMLTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/task/InntektsmeldingXMLTjenesteTest.java
@@ -9,11 +9,6 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
-import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
-import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
-import no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet;
-import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,10 +16,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.familie.inntektsmelding.imdialog.modell.BortaltNaturalytelseEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.KontaktpersonEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
@@ -58,6 +58,7 @@ class InntektsmeldingXMLTjenesteTest {
             .medArbeidsgiverIdent("999999999")
             .medStartDato(LocalDate.of(2024, 6, 1))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedInntekt(BigDecimal.valueOf(35000))
             .medAktørId(aktørIdSøker)
             .medMånedRefusjon(BigDecimal.valueOf(35000))
@@ -92,6 +93,7 @@ class InntektsmeldingXMLTjenesteTest {
             .medArbeidsgiverIdent("999999999")
             .medStartDato(LocalDate.of(2024, 6, 1))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_NÆRSTÅENDE)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedInntekt(BigDecimal.valueOf(35000))
             .medAktørId(aktørIdSøker)
             .medMånedRefusjon(BigDecimal.valueOf(35000))
@@ -133,6 +135,7 @@ class InntektsmeldingXMLTjenesteTest {
             .medArbeidsgiverIdent("999999999")
             .medStartDato(LocalDate.of(2024, 6, 1))
             .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medInntektsmeldingType(InntektsmeldingType.OMSORGSPENGER_REFUSJON)
             .medMånedInntekt(BigDecimal.valueOf(35000))
             .medAktørId(aktørIdSøker)
             .medMånedRefusjon(BigDecimal.valueOf(35000))

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMapperTest.java
@@ -25,6 +25,7 @@ import no.nav.familie.inntektsmelding.imdialog.modell.RefusjonsendringEntitet;
 import no.nav.familie.inntektsmelding.imdialog.rest.OmsorgspengerRequestDto;
 import no.nav.familie.inntektsmelding.imdialog.rest.SendInntektsmeldingRequest;
 import no.nav.familie.inntektsmelding.koder.Endringsårsak;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.AktørIdDto;
@@ -299,6 +300,7 @@ class InntektsmeldingMapperTest {
             .medAktørId(new AktørIdEntitet("9999999999999"))
             .medKontaktperson(new KontaktpersonEntitet("Første", "999999999"))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedInntekt(BigDecimal.valueOf(5000))
             .medMånedRefusjon(BigDecimal.valueOf(5000))
             .medRefusjonOpphørsdato(LocalDate.now().plusDays(5))
@@ -366,6 +368,7 @@ class InntektsmeldingMapperTest {
             .medAktørId(new AktørIdEntitet("9999999999999"))
             .medKontaktperson(new KontaktpersonEntitet("Første", "999999999"))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedInntekt(BigDecimal.valueOf(5000))
             .medMånedRefusjon(BigDecimal.valueOf(5000))
             .medRefusjonOpphørsdato(LocalDate.now().plusDays(10))
@@ -436,6 +439,7 @@ class InntektsmeldingMapperTest {
             .medAktørId(new AktørIdEntitet("9999999999999"))
             .medKontaktperson(new KontaktpersonEntitet("Første", "999999999"))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedInntekt(BigDecimal.valueOf(5000))
             .medMånedRefusjon(BigDecimal.valueOf(5000))
             .medRefusjonOpphørsdato(Tid.TIDENES_ENDE)
@@ -501,6 +505,7 @@ class InntektsmeldingMapperTest {
             .medAktørId(new AktørIdEntitet("9999999999999"))
             .medKontaktperson(new KontaktpersonEntitet("Første", "999999999"))
             .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medInntektsmeldingType(InntektsmeldingType.OMSORGSPENGER_REFUSJON)
             .medMånedInntekt(BigDecimal.valueOf(5000))
             .medMånedRefusjon(BigDecimal.valueOf(5000))
             .medRefusjonOpphørsdato(LocalDate.now().plusDays(10))

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfDataMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/InntektsmeldingPdfDataMapperTest.java
@@ -21,6 +21,7 @@ import no.nav.familie.inntektsmelding.imdialog.modell.RefusjonsendringEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.koder.Endringsårsak;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
@@ -302,6 +303,7 @@ class InntektsmeldingPdfDataMapperTest {
             .medAktørId(AKTØRID_SØKER)
             .medKontaktperson(new KontaktpersonEntitet(NAVN, ORG_NUMMER))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedInntekt(INNTEKT)
             .medStartDato(START_DATO)
             .medMånedRefusjon(REFUSJON_BELØP)

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerInntektsmeldingPdfDataMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerInntektsmeldingPdfDataMapperTest.java
@@ -21,6 +21,7 @@ import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.koder.Endringsårsak;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.familie.inntektsmelding.utils.FormatUtils;
@@ -158,6 +159,7 @@ class OmsorgspengerInntektsmeldingPdfDataMapperTest {
             .medAktørId(AKTØRID_SØKER)
             .medKontaktperson(new KontaktpersonEntitet(NAVN, ORG_NUMMER))
             .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medInntektsmeldingType(InntektsmeldingType.OMSORGSPENGER_REFUSJON)
             .medMånedInntekt(INNTEKT)
             .medStartDato(START_DATO)
             .medOpprettetTidspunkt(OPPRETTETT_TIDSPUNKT)

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfDataMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/OmsorgspengerRefusjonPdfDataMapperTest.java
@@ -22,6 +22,7 @@ import no.nav.familie.inntektsmelding.imdialog.modell.PeriodeEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.koder.Endringsårsak;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.familie.inntektsmelding.utils.FormatUtils;
@@ -173,6 +174,7 @@ class OmsorgspengerRefusjonPdfDataMapperTest {
             .medAktørId(AKTØRID_SØKER)
             .medKontaktperson(new KontaktpersonEntitet(NAVN, ORG_NUMMER))
             .medYtelsetype(Ytelsetype.OMSORGSPENGER)
+            .medInntektsmeldingType(InntektsmeldingType.OMSORGSPENGER_REFUSJON)
             .medMånedInntekt(INNTEKT)
             .medStartDato(START_DATO)
             .medMånedRefusjon(REFUSJON_BELØP)

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/joark/JoarkTjenesteTest.java
@@ -27,6 +27,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTje
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
 import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
@@ -71,6 +72,7 @@ class JoarkTjenesteTest {
             .medArbeidsgiverIdent(arbeidsgiverIdent)
             .medStartDato(LocalDate.of(2024, 6, 1))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medRefusjonOpphørsdato(Tid.TIDENES_ENDE)
             .medMånedRefusjon(BigDecimal.valueOf(35000))
             .medMånedInntekt(BigDecimal.valueOf(35000))
@@ -119,6 +121,7 @@ class JoarkTjenesteTest {
             .medArbeidsgiverIdent(aktørIdArbeidsgiver)
             .medStartDato(LocalDate.of(2024, 6, 1))
             .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
             .medMånedInntekt(BigDecimal.valueOf(35000))
             .medRefusjonOpphørsdato(Tid.TIDENES_ENDE)
             .medMånedRefusjon(BigDecimal.valueOf(35000))


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi har behov for å sende med InntektsmeldingType i inntektsmeldingen slik at k9-sak kan godta inntektsmeldinger som ikke ligger på skjæringstidspunkt dersom de er av typen ARBEIDSGIVERINITIERT.

Jira: https://jira.adeo.no/browse/TSFF-2113

### **Løsning**
XML-kontrakten til inntektsmeldingen er det ikke vi som eier, så vi kan ikke gjøre endringer på den. Sender derfor InntektsmeldingType som en del av tilleggsopplysninger i journalposten.

### Relaterte PR-er
- https://github.com/navikt/k9-abakus/pull/352
- https://github.com/navikt/k9-sak/pull/12191